### PR TITLE
minion: Add golang profiler support to the minion

### DIFF
--- a/minion/main.go
+++ b/minion/main.go
@@ -2,11 +2,14 @@
 package main
 
 import (
+	"time"
+
 	"github.com/NetSys/quilt/db"
 	"github.com/NetSys/quilt/minion/consensus"
 	"github.com/NetSys/quilt/minion/docker"
 	"github.com/NetSys/quilt/minion/elector"
 	"github.com/NetSys/quilt/minion/network"
+	"github.com/NetSys/quilt/minion/pprofile"
 	"github.com/NetSys/quilt/minion/scheduler"
 	"github.com/NetSys/quilt/minion/supervisor"
 	"github.com/NetSys/quilt/util"
@@ -15,6 +18,9 @@ import (
 )
 
 func main() {
+	// XXX Uncomment the following line to run the profiler
+	//runProfiler(5 * time.Minute)
+
 	log.Info("Minion Start")
 
 	log.SetFormatter(util.Formatter{})
@@ -39,4 +45,15 @@ func main() {
 			return nil
 		})
 	}
+}
+
+func runProfiler(duration time.Duration) {
+	go func() {
+		p := pprofile.New("minion")
+		for {
+			if err := p.TimedRun(duration); err != nil {
+				log.Error(err)
+			}
+		}
+	}()
 }

--- a/minion/pprofile/pprofile.go
+++ b/minion/pprofile/pprofile.go
@@ -1,0 +1,66 @@
+package pprofile
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"time"
+)
+
+// To profile:
+//   - The profiler produces a .prof file, we'll call it 'minion.prof'
+//   - SCP minion.prof to your computer
+//   - Run `go tool pprof -pdf path/to/minion path/to/minion.prof > minion.pdf`
+//   - minion.pdf contains the results of the profile run
+
+type profiler interface {
+	Start() error
+	Stop() error
+	TimedRun(time.Duration) error
+}
+
+type prof struct {
+	fname string
+	fd    *os.File
+}
+
+// Only one profiler can run at a time.
+func New(name string) prof {
+	return prof{
+		fname: fmt.Sprintf("/%s.prof", name),
+	}
+}
+
+// Start a new run of the profiler.
+func (pro *prof) Start() error {
+	fd, err := os.Create(pro.fname + ".tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create tmp file: %s", err)
+	}
+	pro.fd = fd
+	pprof.StartCPUProfile(pro.fd)
+	return nil
+}
+
+// Stop profiling and output results to a file
+func (pro *prof) Stop() error {
+	pprof.StopCPUProfile()
+	pro.fd.Close()
+	if err := os.Rename(pro.fname+".tmp", pro.fname); err != nil {
+		return fmt.Errorf("failed to rename tmp file: %s", err)
+	}
+	return nil
+}
+
+// A convenience function that starts and then stops after a given duration
+func (pro *prof) TimedRun(duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	if err := pro.Start(); err != nil {
+		return err
+	}
+	<-timer.C
+	if err := pro.Stop(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
There is currently only a placeholder method to invoking the profiler,
which is to compile the minion to run with the profiler.