### PR TITLE
Refactor to account for tabstop=8

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -112,7 +112,8 @@ func (clst cluster) updateCloud(machines []provider.Machine, boot bool) {
 		actionString = "boot"
 	}
 
-	log.WithField("count", len(machines)).Infof("Attempt to %s machines.", actionString)
+	log.WithField("count", len(machines)).
+		Infof("Attempt to %s machines.", actionString)
 
 	noFailures := true
 	groupedMachines := provider.GroupBy(machines)
@@ -131,7 +132,8 @@ func (clst cluster) updateCloud(machines []provider.Machine, boot bool) {
 		}
 		if err != nil {
 			noFailures = false
-			log.WithError(err).Warnf("Unable to %s machines on %s.", actionString, p)
+			log.WithError(err).
+				Warnf("Unable to %s machines on %s.", actionString, p)
 		}
 	}
 
@@ -204,8 +206,9 @@ func (clst cluster) sync() {
 				dbm.CloudID = m.ID
 				dbm.PublicIP = m.PublicIP
 				dbm.PrivateIP = m.PrivateIP
-				// If we overwrite the machine's size before the machine has fully
-				// booted, the DSL will flip it back immediately.
+				// If we overwrite the machine's size before the machine
+				// has fully booted, the DSL will flip it back
+				// immediately.
 				if m.Size != "" {
 					dbm.Size = m.Size
 				}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -106,17 +106,20 @@ func newTestCluster() cluster {
 func TestSyncDB(t *testing.T) {
 	spew := spew.NewDefaultConfig()
 	spew.MaxDepth = 2
-	checkSyncDB := func(cloudMachines []provider.Machine, databaseMachines []db.Machine,
-		expectedBoot, expectedStop []provider.Machine) {
+	checkSyncDB := func(cloudMachines []provider.Machine,
+		databaseMachines []db.Machine, expectedBoot,
+		expectedStop []provider.Machine) {
 		_, bootResult, stopResult := syncDB(cloudMachines, databaseMachines)
-		if !emptySlices(bootResult, expectedBoot) && !reflect.DeepEqual(bootResult,
-			expectedBoot) {
-			t.Error(spew.Sprintf("booted wrong machines. Expected %v, got %v.",
+		if !emptySlices(bootResult, expectedBoot) &&
+			!reflect.DeepEqual(bootResult, expectedBoot) {
+			t.Error(spew.Sprintf(
+				"booted wrong machines. Expected %v, got %v.",
 				expectedBoot, bootResult))
 		}
-		if !emptySlices(stopResult, expectedStop) && !reflect.DeepEqual(stopResult,
-			expectedStop) {
-			t.Error(spew.Sprintf("stopped wrong machines. Expected %v, got %v.",
+		if !emptySlices(stopResult, expectedStop) && !reflect.DeepEqual(
+			stopResult, expectedStop) {
+			t.Error(spew.Sprintf(
+				"stopped wrong machines. Expected %v, got %v.",
 				expectedStop, stopResult))
 		}
 	}
@@ -136,8 +139,8 @@ func TestSyncDB(t *testing.T) {
 		noMachines)
 
 	// Test mixed boot
-	checkSyncDB(noMachines, []db.Machine{dbNoSize, dbLarge}, []provider.Machine{cmNoSize,
-		cmLarge}, noMachines)
+	checkSyncDB(noMachines, []db.Machine{dbNoSize, dbLarge}, []provider.Machine{
+		cmNoSize, cmLarge}, noMachines)
 
 	// Test partial boot
 	checkSyncDB([]provider.Machine{cmNoSize}, []db.Machine{dbNoSize, dbLarge},
@@ -162,14 +165,17 @@ func TestSync(t *testing.T) {
 		bootResult := providerInst.bootRequests
 		stopResult := providerInst.stopRequests
 		providerInst.clearLogs()
-		if !emptySlices(bootResult, expectedBoot) && !reflect.DeepEqual(bootResult,
-			expectedBoot) {
-			t.Error(spew.Sprintf("booted wrong machines. Expected %s, got %s.",
+		if !emptySlices(bootResult, expectedBoot) &&
+			!reflect.DeepEqual(bootResult, expectedBoot) {
+			t.Error(spew.Sprintf(
+				"booted wrong machines. Expected %s, got %s.",
 				expectedBoot, bootResult))
 		}
-		if !emptySlices(stopResult, expectedStop) && !reflect.DeepEqual(stopResult,
-			expectedStop) {
-			t.Error(spew.Sprintf("stopped wrong machines. Expected %s, got %s.",
+		if !emptySlices(stopResult, expectedStop) &&
+			!reflect.DeepEqual(stopResult,
+				expectedStop) {
+			t.Error(spew.Sprintf(
+				"stopped wrong machines. Expected %s, got %s.",
 				expectedStop, stopResult))
 		}
 	}

--- a/cluster/provider/azure.go
+++ b/cluster/provider/azure.go
@@ -83,8 +83,10 @@ func (clst *azureCluster) List() ([]Machine, error) {
 		}
 		id := hs.ServiceName
 
-		// Will return empty string if the hostedservice does not have a deployment.
-		// e.g. some hosted services contains only a storage account, but no deployment.
+		// Will return empty string if the hostedservice does not have a
+		// deployment.
+		// e.g. some hosted services contains only a storage account, but no
+		// deployment.
 		deploymentName, err := clst.vmClient.GetDeploymentName(id)
 		if err != nil {
 			return nil, err
@@ -95,7 +97,8 @@ func (clst *azureCluster) List() ([]Machine, error) {
 			continue
 		}
 
-		deploymentResponse, err := clst.vmClient.GetDeployment(id, deploymentName)
+		deploymentResponse, err := clst.vmClient.GetDeployment(id,
+			deploymentName)
 		if err != nil {
 			return nil, err
 		}
@@ -160,7 +163,8 @@ func (clst *azureCluster) ChooseSize(ram stitch.Range, cpu stitch.Range,
 func (clst *azureCluster) instanceNew(name string, vmSize string, region string,
 	cloudConfig string) error {
 	if region != clst.location {
-		return fmt.Errorf("cannot create instance in %s, only %s is supported", region,
+		return fmt.Errorf("cannot create instance in %s, only %s is supported",
+			region,
 			clusterLocation)
 	}
 	// create hostedservice

--- a/cluster/provider/gce.go
+++ b/cluster/provider/gce.go
@@ -113,8 +113,9 @@ func (clst *gceCluster) List() ([]Machine, error) {
 			machineSplitURL := strings.Split(item.MachineType, "/")
 			mtype := machineSplitURL[len(machineSplitURL)-1]
 			mList = append(mList, Machine{
-				ID:        item.Name,
-				PublicIP:  item.NetworkInterfaces[0].AccessConfigs[0].NatIP,
+				ID: item.Name,
+				PublicIP: item.NetworkInterfaces[0].
+					AccessConfigs[0].NatIP,
 				PrivateIP: item.NetworkInterfaces[0].NetworkIP,
 				Size:      mtype,
 				Region:    zone,
@@ -255,7 +256,8 @@ func (clst *gceCluster) operationWait(ops []*compute.Operation, domain int) erro
 				switch {
 				case domain == local:
 					op, err = gceService.ZoneOperations.
-						Get(clst.projID, ops[0].Zone, ops[0].Name).Do()
+						Get(clst.projID, ops[0].Zone,
+							ops[0].Name).Do()
 				case domain == global:
 					op, err = gceService.GlobalOperations.
 						Get(clst.projID, ops[0].Name).Do()

--- a/cluster/provider/provider_test.go
+++ b/cluster/provider/provider_test.go
@@ -65,8 +65,8 @@ func TestDefaultRegion(t *testing.T) {
 }
 
 func TestConstraints(t *testing.T) {
-	checkConstraint := func(descriptions []Description, ram stitch.Range, cpu stitch.Range,
-		maxPrice float64, exp string) {
+	checkConstraint := func(descriptions []Description, ram stitch.Range,
+		cpu stitch.Range, maxPrice float64, exp string) {
 		resSize := pickBestSize(descriptions, ram, cpu, maxPrice)
 		if resSize != exp {
 			t.Errorf("bad size picked. Expected %s, got %s", exp, resSize)

--- a/cluster/provider/vagrant.go
+++ b/cluster/provider/vagrant.go
@@ -84,7 +84,9 @@ func (clst vagrantCluster) List() ([]Machine, error) {
 	for _, instanceID := range instanceIDs {
 		ip, err := vagrant.PublicIP(instanceID)
 		if err != nil {
-			log.WithError(err).Infof("Failed to retrieve IP address for %s.", instanceID)
+			log.WithError(err).Infof(
+				"Failed to retrieve IP address for %s.",
+				instanceID)
 		}
 		instance := Machine{
 			ID:        instanceID,

--- a/cluster/provider/vagrant_api.go
+++ b/cluster/provider/vagrant_api.go
@@ -70,7 +70,8 @@ func (api vagrantAPI) Up(id string) error {
 }
 
 func (api vagrantAPI) Destroy(id string) error {
-	_, err := api.Shell(id, `vagrant --machine-readable destroy -f; cd ../; rm -rf %s`)
+	_, err := api.Shell(id,
+		`vagrant --machine-readable destroy -f; cd ../; rm -rf %s`)
 	if err != nil {
 		return err
 	}
@@ -78,7 +79,8 @@ func (api vagrantAPI) Destroy(id string) error {
 }
 
 func (api vagrantAPI) PublicIP(id string) (string, error) {
-	ip, err := api.Shell(id, `vagrant ssh -c "ip address show eth1 | grep 'inet ' | " +
+	ip, err := api.Shell(id,
+		`vagrant ssh -c "ip address show eth1 | grep 'inet ' | " +
 		"sed -e 's/^.*inet //' -e 's/\/.*$//' | tr -d '\n'"`)
 	if err != nil {
 		return "", err

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -134,7 +134,8 @@ func toDBMachine(machines []stitch.Machine, maxPrice float64) []db.Machine {
 
 		if m.Size == "" {
 			providerInst := provider.New(p)
-			m.Size = providerInst.ChooseSize(stitchm.RAM, stitchm.CPU, maxPrice)
+			m.Size = providerInst.ChooseSize(
+				stitchm.RAM, stitchm.CPU, maxPrice)
 			if m.Size == "" {
 				log.Errorf("No valid size for %v, skipping.", m)
 				continue

--- a/inspect/inspect_test.go
+++ b/inspect/inspect_test.go
@@ -65,7 +65,8 @@ func TestReach(t *testing.T) {
 	specPath := "./test/reach.spec"
 	invariantPath := "./test/reach.inv"
 	// Correct result: all invariants pass.
-	if failer, err := runInvTest(specPath, invariantPath); err != nil || failer != "" {
+	if failer, err := runInvTest(specPath, invariantPath); err != nil ||
+		failer != "" {
 		t.Errorf("%s %s", err, failer)
 	}
 }
@@ -74,7 +75,8 @@ func TestBetween(t *testing.T) {
 	specPath := "./test/between.spec"
 	invariantPath := "./test/between.inv"
 	// Correct result: all invariants pass.
-	if failer, err := runInvTest(specPath, invariantPath); err != nil || failer != "" {
+	if failer, err := runInvTest(specPath, invariantPath); err != nil ||
+		failer != "" {
 		t.Errorf("%s %s", err, failer)
 	}
 }
@@ -95,7 +97,8 @@ func TestEnough(t *testing.T) {
 	specPath := "./test/placement.spec"
 	invariantPath := "./test/enough.inv"
 	// correct result: all invariants pass
-	if failer, err := runInvTest(specPath, invariantPath); err != nil || failer != "" {
+	if failer, err := runInvTest(specPath, invariantPath); err != nil ||
+		failer != "" {
 		t.Errorf("%s %s", err, failer)
 	}
 }

--- a/inspect/main.go
+++ b/inspect/main.go
@@ -123,7 +123,8 @@ func main() {
 						if err != nil {
 							fmt.Println(err)
 						} else {
-							fmt.Println("query passed invariants")
+							fmt.Println("query passed " +
+								"invariants")
 						}
 					}
 				}(i)

--- a/inspect/placement.go
+++ b/inspect/placement.go
@@ -74,7 +74,8 @@ func (g *graph) addPlacementRule(rule stitch.Placement) {
 		for _, lab := range g.getNodes() {
 			if lab.name != stitch.PublicInternetLabel {
 				allLabels = append(allLabels, lab.name)
-				g.placement[lab.name] = append(g.placement[lab.name], stitch.PublicInternetLabel)
+				g.placement[lab.name] = append(g.placement[lab.name],
+					stitch.PublicInternetLabel)
 			}
 		}
 		g.placement[stitch.PublicInternetLabel] = allLabels
@@ -86,14 +87,16 @@ func (g *graph) addPlacementRule(rule stitch.Placement) {
 func validateRule(place stitch.Placement, g graph) (string, string) {
 	targetNode, ok := g.nodes[place.TargetLabel]
 	if !ok {
-		panic(fmt.Errorf("placement constraint: node not found: %s", place.TargetLabel))
+		panic(fmt.Errorf("placement constraint: node not found: %s",
+			place.TargetLabel))
 	}
 
 	var wantExclusive string
 	if place.OtherLabel != "" {
 		other, ok := g.nodes[place.OtherLabel]
 		if !ok {
-			panic(fmt.Errorf("placement constraint: node not found: %s", other))
+			panic(fmt.Errorf("placement constraint: node not found: %s",
+				other))
 		}
 
 		if other.name != targetNode.name {
@@ -151,7 +154,8 @@ func (g *graph) placeNodes() {
 					if ind+1 >= len(toMove) {
 						toMove = toMove[:ind]
 					} else {
-						toMove = append(toMove[:ind], toMove[ind+1:]...)
+						toMove = append(toMove[:ind],
+							toMove[ind+1:]...)
 					}
 					break
 				}

--- a/inspect/query.go
+++ b/inspect/query.go
@@ -58,7 +58,9 @@ func askQueries(graph graph, invs []invariant, queries []query) (*query, *invari
 		if val := queryFormImpls[query.form](graph, invs, query); val != nil {
 			return &query,
 				val,
-				fmt.Errorf("mutation %s failed invariant %s", query.str, val.str)
+				fmt.Errorf(
+					"mutation %s failed invariant %s",
+					query.str, val.str)
 		}
 	}
 
@@ -111,7 +113,8 @@ func whatIfRemoveSet(graph graph, invs []invariant, query query) *invariant {
 	node := query.target
 	avSet := graphCopy.findAvailabilitySet(node)
 	if avSet == nil {
-		return &invariant{str: fmt.Sprintf("could not find availability set: %s", node)}
+		return &invariant{str: fmt.Sprintf(
+			"could not find availability set: %s", node)}
 	}
 
 	graphCopy.removeAvailabiltySet(avSet)

--- a/inspect/viz.go
+++ b/inspect/viz.go
@@ -105,9 +105,11 @@ func graphviz(outputFormat string, slug string, graph graph,
 	var writeGraph *exec.Cmd
 	switch outputFormat {
 	case "ascii":
-		writeGraph = exec.Command("graph-easy", "--input="+slug+".dot", "--as_ascii")
+		writeGraph = exec.Command("graph-easy", "--input="+slug+".dot",
+			"--as_ascii")
 	case "pdf":
-		writeGraph = exec.Command("dot", "-Tpdf", "-o", slug+".pdf", slug+".dot")
+		writeGraph = exec.Command("dot", "-Tpdf", "-o", slug+".pdf",
+			slug+".dot")
 	}
 	writeGraph.Stdout = os.Stdout
 	writeGraph.CombinedOutput()

--- a/minion/docker/docker.go
+++ b/minion/docker/docker.go
@@ -362,8 +362,8 @@ func (dk docker) IsRunning(name string) (bool, error) {
 	return len(containers) != 0, nil
 }
 
-func (dk docker) create(name, image string, args []string,
-	labels map[string]string, env map[string]struct{}, hc *dkc.HostConfig) (string, error) {
+func (dk docker) create(name, image string, args []string, labels map[string]string,
+	env map[string]struct{}, hc *dkc.HostConfig) (string, error) {
 	if err := dk.Pull(image); err != nil {
 		return "", err
 	}
@@ -374,8 +374,12 @@ func (dk docker) create(name, image string, args []string,
 	}
 
 	container, err := dk.CreateContainer(dkc.CreateContainerOptions{
-		Name:       name,
-		Config:     &dkc.Config{Image: string(image), Cmd: args, Labels: labels, Env: envList},
+		Name: name,
+		Config: &dkc.Config{
+			Image:  string(image),
+			Cmd:    args,
+			Labels: labels,
+			Env:    envList},
 		HostConfig: hc,
 	})
 	if err != nil {

--- a/minion/engine_test.go
+++ b/minion/engine_test.go
@@ -242,7 +242,8 @@ func testConnectionTxn(conn db.Conn, spec string) string {
 		for i, c := range connections {
 			if e.From == c.From && e.To == c.To && e.MinPort == c.MinPort &&
 				e.MaxPort == c.MaxPort {
-				connections = append(connections[:i], connections[i+1:]...)
+				connections = append(
+					connections[:i], connections[i+1:]...)
 				found = true
 				break
 			}

--- a/minion/network/network.go
+++ b/minion/network/network.go
@@ -176,10 +176,12 @@ func updateACLs(connections []db.Connection, labels []db.Label,
 			max := conn.MaxPort
 
 			match := fmt.Sprintf("ip4.src==%s && ip4.dst==%s && "+
-				"(icmp || %d <= udp.dst <= %d || %[3]d <= tcp.dst <= %[4]d)",
+				"(icmp || %d <= udp.dst <= %d || "+
+				"%[3]d <= tcp.dst <= %[4]d)",
 				fromIP, toIP, min, max)
 			reverse := fmt.Sprintf("ip4.src==%s && ip4.dst==%s && "+
-				"(icmp || %d <= udp.src <= %d || %[3]d <= tcp.src <= %[4]d)",
+				"(icmp || %d <= udp.src <= %d || "+
+				"%[3]d <= tcp.src <= %[4]d)",
 				toIP, fromIP, min, max)
 
 			matchSet[match] = struct{}{}

--- a/minion/network/network_test.go
+++ b/minion/network/network_test.go
@@ -36,7 +36,8 @@ func TestACL(t *testing.T) {
 
 	// `expACLs` should NOT contain the default rules.
 	checkAcl := func(connections []db.Connection, labels []db.Label,
-		containers []db.Container, coreExpACLs []ovsdb.AclCore, resetClient bool) {
+		containers []db.Container, coreExpACLs []ovsdb.AclCore,
+		resetClient bool) {
 		if resetClient {
 			client = fakeOvsdb{}
 		}
@@ -55,7 +56,8 @@ func TestACL(t *testing.T) {
 		sort.Sort(ACLList(res))
 		if !reflect.DeepEqual(expACLs, res) {
 			_, _, callerLine, _ := runtime.Caller(1)
-			t.Errorf("Test at line %d failed. Expected %v, got %v.", callerLine, expACLs, res)
+			t.Errorf("Test at line %d failed. Expected %v, got %v.",
+				callerLine, expACLs, res)
 		}
 	}
 
@@ -74,7 +76,8 @@ func TestACL(t *testing.T) {
 		IP: purpleLabelIP}
 	redBlueLabel := db.Label{Label: "redBlue",
 		IP: redBlueLabelIP}
-	allLabels := []db.Label{redLabel, blueLabel, yellowLabel, purpleLabel, redBlueLabel}
+	allLabels := []db.Label{redLabel, blueLabel, yellowLabel, purpleLabel,
+		redBlueLabel}
 
 	redContainerIP := "100.1.1.1"
 	blueContainerIP := "100.1.1.2"
@@ -98,10 +101,12 @@ func TestACL(t *testing.T) {
 	matchFmt := "ip4.src==%s && ip4.dst==%s && " +
 		"(icmp || %d <= udp.dst <= %d || %[3]d <= tcp.dst <= %[4]d)"
 	reverseFmt := "ip4.src==%s && ip4.dst==%s && " +
-		"(icmp || %d <= udp.src <= %d || %[3]d <= tcp.src <= %[4]d)"
+		"(icmp || %d <= udp.src <= %d || " +
+		"%[3]d <= tcp.src <= %[4]d)"
 
 	// No connections should result in no ACLs but the default drop rules.
-	checkAcl([]db.Connection{}, []db.Label{}, []db.Container{}, []ovsdb.AclCore{}, true)
+	checkAcl([]db.Connection{}, []db.Label{}, []db.Container{}, []ovsdb.AclCore{},
+		true)
 
 	// Test one connection (with range)
 	checkAcl([]db.Connection{
@@ -113,22 +118,26 @@ func TestACL(t *testing.T) {
 		allContainers,
 		[]ovsdb.AclCore{
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, blueLabelIP, 80, 81),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					blueLabelIP, 80, 81),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, blueLabelIP, 80, 81),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					blueLabelIP, 80, 81),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(reverseFmt, blueLabelIP, redContainerIP, 80, 81),
+				Match: fmt.Sprintf(reverseFmt, blueLabelIP,
+					redContainerIP, 80, 81),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(reverseFmt, blueLabelIP, redContainerIP, 80, 81),
+				Match: fmt.Sprintf(reverseFmt, blueLabelIP,
+					redContainerIP, 80, 81),
 				Action:   "allow",
 				Priority: 1,
 			}},
@@ -144,42 +153,50 @@ func TestACL(t *testing.T) {
 		allContainers,
 		[]ovsdb.AclCore{
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, yellowLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					yellowLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, yellowLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					yellowLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(reverseFmt, yellowLabelIP, redContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, yellowLabelIP,
+					redContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(reverseFmt, yellowLabelIP, redContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, yellowLabelIP,
+					redContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(matchFmt, blueContainerIP, yellowLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, blueContainerIP,
+					yellowLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(matchFmt, blueContainerIP, yellowLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, blueContainerIP,
+					yellowLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(reverseFmt, yellowLabelIP, blueContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, yellowLabelIP,
+					blueContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(reverseFmt, yellowLabelIP, blueContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, yellowLabelIP,
+					blueContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			}},
@@ -195,22 +212,26 @@ func TestACL(t *testing.T) {
 		allContainers,
 		[]ovsdb.AclCore{
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, blueLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					blueLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, blueLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					blueLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(reverseFmt, blueLabelIP, redContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, blueLabelIP,
+					redContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(reverseFmt, blueLabelIP, redContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, blueLabelIP,
+					redContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			}},
@@ -235,42 +256,50 @@ func TestACL(t *testing.T) {
 		allContainers,
 		[]ovsdb.AclCore{
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, blueLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					blueLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(matchFmt, redContainerIP, blueLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, redContainerIP,
+					blueLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(reverseFmt, blueLabelIP, redContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, blueLabelIP,
+					redContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(reverseFmt, blueLabelIP, redContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, blueLabelIP,
+					redContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(matchFmt, yellowContainerIP, purpleLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, yellowContainerIP,
+					purpleLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(matchFmt, yellowContainerIP, purpleLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, yellowContainerIP,
+					purpleLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(reverseFmt, purpleLabelIP, yellowContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, purpleLabelIP,
+					yellowContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(reverseFmt, purpleLabelIP, yellowContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, purpleLabelIP,
+					yellowContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			}},
@@ -284,22 +313,26 @@ func TestACL(t *testing.T) {
 		allContainers,
 		[]ovsdb.AclCore{
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(matchFmt, yellowContainerIP, purpleLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, yellowContainerIP,
+					purpleLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(matchFmt, yellowContainerIP, purpleLabelIP, 80, 80),
+				Match: fmt.Sprintf(matchFmt, yellowContainerIP,
+					purpleLabelIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "to-lport",
-				Match:    fmt.Sprintf(reverseFmt, purpleLabelIP, yellowContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, purpleLabelIP,
+					yellowContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			},
 			{Direction: "from-lport",
-				Match:    fmt.Sprintf(reverseFmt, purpleLabelIP, yellowContainerIP, 80, 80),
+				Match: fmt.Sprintf(reverseFmt, purpleLabelIP,
+					yellowContainerIP, 80, 80),
 				Action:   "allow",
 				Priority: 1,
 			}},
@@ -366,8 +399,8 @@ func (odb *fakeOvsdb) DeleteACL(lswitch string, dir string, priority int,
 			continue
 		}
 		odb.acls = append(odb.acls[:i], odb.acls[i+1:]...)
-		// Because deleting an element shifts the i+1th element into the ith spot,
-		// we need to stay at the same index to not skip the next element.
+		// Because deleting an element shifts the i+1th element into the ith
+		// spot, we need to stay at the same index to not skip the next element.
 		i--
 	}
 	return nil

--- a/minion/network/store.go
+++ b/minion/network/store.go
@@ -264,8 +264,8 @@ func writeStoreLabels(store consensus.Store, containers []db.Container) error {
 }
 
 func syncDir(store consensus.Store, dir directory, path string, idsArg []string) {
-	_, dirKeys, ids := join.HashJoin(StringSlice(dir.keys()), StringSlice(idsArg), nil,
-		nil)
+	_, dirKeys, ids := join.HashJoin(StringSlice(dir.keys()), StringSlice(idsArg),
+		nil, nil)
 
 	var etcdLog string
 	for _, dirKey := range dirKeys {

--- a/minion/network/worker.go
+++ b/minion/network/worker.go
@@ -359,7 +359,7 @@ func generateCurrentVeths(containers []db.Container) (netdevSlice, error) {
 				log.WithFields(log.Fields{
 					"namespace": cfg.peerNS,
 					"error":     err,
-				}).Error("error searching for namespace")
+				}).Error("error while searching for namespace")
 				continue
 			} else if nsExists {
 				lkExists, err := linkExists(cfg.peerNS, innerVeth)
@@ -368,7 +368,8 @@ func generateCurrentVeths(containers []db.Container) (netdevSlice, error) {
 						"namespace": cfg.peerNS,
 						"link":      innerVeth,
 						"error":     err,
-					}).Error("error checking if link exists in namespace")
+					}).Error("error while checking " +
+						"whether link exists in namespace")
 					continue
 				} else if lkExists {
 					cfg.peerMTU, err = getLinkMTU(cfg.peerNS, innerVeth)

--- a/minion/network/worker_test.go
+++ b/minion/network/worker_test.go
@@ -134,7 +134,8 @@ func TestMakeIPRule(t *testing.T) {
 			expOpts, rule.opts)
 	}
 
-	inp = "-A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT --to-destination 10.31.0.23:80"
+	inp = "-A PREROUTING -i eth0 -p tcp --dport 80 -j DNAT " +
+		"--to-destination 10.31.0.23:80"
 	rule, _ = makeIPRule(inp)
 	expCmd = "-A"
 	expChain = "PREROUTING"
@@ -229,14 +230,17 @@ func TestGenerateCurrentNatRules(t *testing.T) {
 func TestMakeOFRule(t *testing.T) {
 	flows := []string{
 		"cookie=0x0, duration=997.526s, table=0, n_packets=0, " +
-			"n_bytes=0, idle_age=997, priority=5000,in_port=3 actions=output:7",
+			"n_bytes=0, idle_age=997, priority=5000,in_port=3 " +
+			"actions=output:7",
 
 		"cookie=0x0, duration=997.351s, table=1, n_packets=0, " +
-			"n_bytes=0, idle_age=997, priority=4000,ip,dl_dst=0a:00:00:00:00:00," +
+			"n_bytes=0, idle_age=997, priority=4000,ip," +
+			"dl_dst=0a:00:00:00:00:00," +
 			"nw_dst=10.1.4.66 actions=LOCAL",
 
 		"cookie=0x0, duration=159.314s, table=2, n_packets=0, n_bytes=0, " +
-			"idle_age=159, priority=4000,ip,dl_dst=0a:00:00:00:00:00,nw_dst=10.1.4.66 " +
+			"idle_age=159, priority=4000,ip,dl_dst=0a:00:00:00:00:00," +
+			"nw_dst=10.1.4.66 " +
 			"actions=mod_dl_dst:02:00:0a:00:96:72,resubmit(,2)",
 
 		"cookie=0x0, duration=159.314s, table=2, n_packets=0, n_bytes=0, " +
@@ -275,9 +279,10 @@ func TestMakeOFRule(t *testing.T) {
 	}
 
 	exp3 := OFRule{
-		table:   "table=2",
-		match:   "in_port=6,priority=5000",
-		actions: "multipath(symmetric_l3l4,0,modulo_n,2,0,NXM_NX_REG0[0..1]),resubmit(,1)",
+		table: "table=2",
+		match: "in_port=6,priority=5000",
+		actions: "multipath(symmetric_l3l4,0,modulo_n,2,0,NXM_NX_REG0[0..1])," +
+			"resubmit(,1)",
 	}
 
 	exp4 := OFRule{

--- a/minion/ovsdb/ovsdb.go
+++ b/minion/ovsdb/ovsdb.go
@@ -133,7 +133,8 @@ func newMutation(column, mutator string, value interface{}) mutation {
 		case reflect.Map:
 			mutateValue, err = ovs.NewOvsMap(typedValue)
 		default:
-			panic(fmt.Sprintf("unhandled value in mutation: value %s, type %s",
+			panic(fmt.Sprintf(
+				"unhandled value in mutation: value %s, type %s",
 				value, typedValue))
 		}
 		if err != nil {
@@ -452,8 +453,9 @@ func (ovsdb Client) ListACLs(lswitch string) ([]Acl, error) {
 			return nil, err
 		}
 		for _, result := range results {
+			goUUID := result["_uuid"].([]interface{})[1].(string)
 			acl := Acl{
-				uuid: ovs.UUID{GoUUID: result["_uuid"].([]interface{})[1].(string)},
+				uuid: ovs.UUID{GoUUID: goUUID},
 				Core: AclCore{
 					Priority:  int(result["priority"].(float64)),
 					Direction: result["direction"].(string),

--- a/minion/scheduler/scheduler.go
+++ b/minion/scheduler/scheduler.go
@@ -27,8 +27,9 @@ func Run(conn db.Conn) {
 		db.PlacementTable).C {
 		minions := conn.SelectFromMinion(nil)
 		etcdRows := conn.SelectFromEtcd(nil)
-		if len(minions) != 1 || len(etcdRows) != 1 || minions[0].Role != db.Master ||
-			minions[0].PrivateIP == "" || !etcdRows[0].Leader {
+		if len(minions) != 1 || len(etcdRows) != 1 ||
+			minions[0].Role != db.Master || minions[0].PrivateIP == "" ||
+			!etcdRows[0].Leader {
 			sched = nil
 			continue
 		}

--- a/minion/supervisor/supervisor.go
+++ b/minion/supervisor/supervisor.go
@@ -134,7 +134,8 @@ func (sv *supervisor) runAppTransact(view db.Database,
 		return val.(docker.Container).ID
 	}
 
-	pairs, dbcs, dkcs := join.HashJoin(db.ContainerSlice(view.SelectFromContainer(nil)),
+	pairs, dbcs, dkcs := join.HashJoin(db.ContainerSlice(
+		view.SelectFromContainer(nil)),
 		docker.ContainerSlice(dkcsArgs), dbKey, dkKey)
 
 	for _, iface := range dbcs {

--- a/minion/supervisor/supervisor_test.go
+++ b/minion/supervisor/supervisor_test.go
@@ -187,7 +187,8 @@ func TestWorker(t *testing.T) {
 		Ovsvswitchd: ovsExecArgs(ip, leaderIP),
 	}
 	if !reflect.DeepEqual(ctx.fd.exec, exp) {
-		t.Errorf("fd.exec = %s\n\nwant %s", spew.Sdump(ctx.fd.exec), spew.Sdump(exp))
+		t.Errorf("fd.exec = %s\n\nwant %s", spew.Sdump(ctx.fd.exec),
+			spew.Sdump(exp))
 	}
 }
 
@@ -226,7 +227,8 @@ func TestChange(t *testing.T) {
 		Ovsvswitchd: ovsExecArgs(ip, leaderIP),
 	}
 	if !reflect.DeepEqual(ctx.fd.exec, exp) {
-		t.Errorf("fd.exec = %s\n\nwant %s", spew.Sdump(ctx.fd.exec), spew.Sdump(exp))
+		t.Errorf("fd.exec = %s\n\nwant %s", spew.Sdump(ctx.fd.exec),
+			spew.Sdump(exp))
 	}
 
 	delete(ctx.fd.exec, Ovsvswitchd)
@@ -276,7 +278,8 @@ func TestChange(t *testing.T) {
 		Ovsvswitchd: ovsExecArgs(ip, leaderIP),
 	}
 	if !reflect.DeepEqual(ctx.fd.exec, exp) {
-		t.Errorf("fd.exec = %s\n\nwant %s", spew.Sdump(ctx.fd.exec), spew.Sdump(exp))
+		t.Errorf("fd.exec = %s\n\nwant %s", spew.Sdump(ctx.fd.exec),
+			spew.Sdump(exp))
 	}
 }
 

--- a/stitch/ast.go
+++ b/stitch/ast.go
@@ -129,7 +129,8 @@ func (r astLabelRule) String() string {
 		otherLabels = append(otherLabels, string(l))
 	}
 
-	return fmt.Sprintf("(labelRule %s %s)", exclusiveStr, strings.Join(otherLabels, " "))
+	return fmt.Sprintf("(labelRule %s %s)", exclusiveStr,
+		strings.Join(otherLabels, " "))
 }
 
 func (r astRegion) String() string {
@@ -188,7 +189,8 @@ func (h astHmap) String() string {
 
 	keyValues := []string{}
 	for key, value := range h {
-		keyValues = append(keyValues, fmt.Sprintf("(%s %s)", key.String(), value.String()))
+		keyValues = append(keyValues, fmt.Sprintf("(%s %s)", key.String(),
+			value.String()))
 	}
 	sort.Strings(keyValues)
 

--- a/stitch/eval.go
+++ b/stitch/eval.go
@@ -82,7 +82,8 @@ func (list astList) eval(ctx *evalCtx) (ast, error) {
 func evalLambda(fn astLambda, funcArgs []ast) (ast, error) {
 	parentCtx := fn.ctx
 	if len(fn.argNames) != len(funcArgs) {
-		return nil, fmt.Errorf("bad number of arguments: %s %s", fn.argNames, funcArgs)
+		return nil, fmt.Errorf("bad number of arguments: %s %s", fn.argNames,
+			funcArgs)
 	}
 
 	// Modify the eval context with the argument binds.

--- a/stitch/func.go
+++ b/stitch/func.go
@@ -200,7 +200,9 @@ func setEnvImpl(ctx *evalCtx, args []ast) (ast, error) {
 		case astString, astLabel:
 			label, ok := ctx.resolveLabel(val)
 			if !ok {
-				return nil, fmt.Errorf("cannot setEnv on invalid label: %s", val)
+				return nil,
+					fmt.Errorf("cannot setEnv on invalid label: %s",
+						val)
 			}
 			for _, c := range label.elems {
 				if err := setEnvHelper(c, args[1], args[2]); err != nil {
@@ -212,7 +214,9 @@ func setEnvImpl(ctx *evalCtx, args []ast) (ast, error) {
 				return nil, err
 			}
 		default:
-			return nil, fmt.Errorf("setEnv target must be either a label or container: %s", val)
+			return nil, fmt.Errorf(
+				"setEnv target must be either a label or container: %s",
+				val)
 		}
 	}
 	return astList{}, nil
@@ -237,13 +241,16 @@ func sshkeyImpl(ctx *evalCtx, args []ast) (ast, error) {
 func parseExclusive(arg ast) (astBool, error) {
 	exclusiveAst, ok := arg.(astString)
 	if !ok {
-		return astBool(false), fmt.Errorf("exclusiveness must be a string: %s", arg)
+		return astBool(false), fmt.Errorf("exclusiveness must be a string: %s",
+			arg)
 	}
 
 	exclusiveStr := string(exclusiveAst)
 	if exclusiveStr != "exclusive" && exclusiveStr != "on" {
 		return astBool(false),
-			fmt.Errorf("exclusiveness must be one of \"exclusive\" or \"on\": %s",
+			fmt.Errorf(
+				"exclusiveness must be one of "+
+					"\"exclusive\" or \"on\": %s",
 				exclusiveAst)
 	}
 
@@ -289,7 +296,8 @@ func labelRuleImpl(ctx *evalCtx, args []ast) (ast, error) {
 	for _, label := range flatten(args[1:]) {
 		l, ok := ctx.resolveLabel(label)
 		if !ok {
-			return nil, fmt.Errorf("labelRule constrains on labels: %s", label)
+			return nil, fmt.Errorf("labelRule constrains on labels: %s",
+				label)
 		}
 		labelRule.otherLabels = append(labelRule.otherLabels, l.ident)
 	}
@@ -355,12 +363,15 @@ func setMachineAttributes(machine *astMachine, args []ast) error {
 			case "cpu":
 				machine.cpu = val
 			default:
-				return fmt.Errorf("unrecognized argument to machine definition: %s", arg)
+				return fmt.Errorf(
+					"unrecognized argument to machine definition: %s",
+					arg)
 			}
 		case key:
 			machine.sshKeys = append(machine.sshKeys, val)
 		default:
-			return fmt.Errorf("unrecognized argument to machine definition: %s", arg)
+			return fmt.Errorf(
+				"unrecognized argument to machine definition: %s", arg)
 		}
 	}
 	return nil
@@ -386,7 +397,8 @@ func machineAttributeImpl(ctx *evalCtx, args []ast) (ast, error) {
 	for _, m := range list {
 		machine, ok := m.(*astMachine)
 		if !ok {
-			return nil, fmt.Errorf("bad type, cannot change machine attributes: %s", m)
+			return nil, fmt.Errorf(
+				"bad type, cannot change machine attributes: %s", m)
 		}
 		err := setMachineAttributes(machine, args[1:])
 		if err != nil {
@@ -451,7 +463,8 @@ func rangeTypeImpl(rangeType string) func(*evalCtx, []ast) (ast, error) {
 		min, minErr := toFloat(args[0])
 
 		if minErr != nil || maxErr != nil {
-			return nil, fmt.Errorf("range arguments must be convertable to floats: %v",
+			return nil, fmt.Errorf(
+				"range arguments must be convertable to floats: %v",
 				args)
 		}
 
@@ -560,10 +573,12 @@ func labelImpl(ctx *evalCtx, args []ast) (ast, error) {
 	}
 	label := string(str)
 	if label != strings.ToLower(label) {
-		log.Error("Labels must be lowercase. https://github.com/docker/swarm/issues/1795")
+		log.Error("Labels must be lowercase. " +
+			"https://github.com/docker/swarm/issues/1795")
 	}
 	if label == PublicInternetLabel {
-		return nil, fmt.Errorf("the \"public\" label is reserved for the public internet")
+		return nil, fmt.Errorf(
+			"the \"public\" label is reserved for the public internet")
 	}
 
 	if _, ok := ctx.resolveLabel(str); ok {
@@ -778,7 +793,8 @@ func logImpl(ctx *evalCtx, args []ast) (ast, error) {
 		log.Errorln(msg)
 	default:
 		return nil,
-			fmt.Errorf("log level must be one of [print, info, debug, warn, error]: %s",
+			fmt.Errorf("log level must be one of "+
+				"[print, info, debug, warn, error]: %s",
 				level)
 	}
 
@@ -870,7 +886,8 @@ func parseBindings(ctx *evalCtx, bindings astSexp) ([]binding, error) {
 	for _, astBinding := range bindings.sexp {
 		bind, ok := astBinding.(astSexp)
 		if !ok || len(bind.sexp) != 2 {
-			return nil, fmt.Errorf("binds must be exactly 2 arguments: %s", astBinding)
+			return nil, fmt.Errorf("binds must be exactly 2 arguments: %s",
+				astBinding)
 		}
 		binds = append(binds, binding{bind.sexp[0], bind.sexp[1]})
 	}

--- a/stitch/parse.go
+++ b/stitch/parse.go
@@ -51,7 +51,8 @@ func parseText(s *scanner.Scanner, depth int) ([]ast, error) {
 				ident += "."
 				if s.Scan() != scanner.Ident {
 					return nil, stitchError{pos: s.Pos(),
-						err: fmt.Errorf("bad ident name: %s", ident)}
+						err: fmt.Errorf("bad ident name: %s",
+							ident)}
 				}
 				ident += s.TokenText()
 			}
@@ -66,8 +67,9 @@ func parseText(s *scanner.Scanner, depth int) ([]ast, error) {
 			str := strings.Trim(s.TokenText(), "\"")
 			slice = append(slice, astString(str))
 		case '(':
-			// We need to save our position before recursing because the scanner
-			// will have moved on by the time the recursive call returns.
+			// We need to save our position before recursing because the
+			// scanner will have moved on by the time the recursive call
+			// returns.
 			pos := s.Pos()
 			sexp, err := parseText(s, depth+1)
 			if err != nil {
@@ -88,7 +90,8 @@ func parseText(s *scanner.Scanner, depth int) ([]ast, error) {
 			return slice, nil
 
 		default:
-			return nil, stitchError{s.Pos(), fmt.Errorf("bad element: %s", s.TokenText())}
+			return nil, stitchError{s.Pos(), fmt.Errorf("bad element: %s",
+				s.TokenText())}
 		}
 	}
 }

--- a/stitch/stitch.go
+++ b/stitch/stitch.go
@@ -166,8 +166,10 @@ func convertAstMachine(machineAst astMachine) Machine {
 		Size:     string(machineAst.size),
 		Role:     string(machineAst.role),
 		Region:   string(machineAst.region),
-		RAM:      Range{Min: float64(machineAst.ram.min), Max: float64(machineAst.ram.max)},
-		CPU:      Range{Min: float64(machineAst.cpu.min), Max: float64(machineAst.cpu.max)},
+		RAM: Range{Min: float64(machineAst.ram.min),
+			Max: float64(machineAst.ram.max)},
+		CPU: Range{Min: float64(machineAst.cpu.min),
+			Max: float64(machineAst.cpu.max)},
 		DiskSize: int(machineAst.diskSize),
 		SSHKeys:  parseKeys(machineAst.sshKeys),
 	}

--- a/stitch/stitch_test.go
+++ b/stitch/stitch_test.go
@@ -652,7 +652,8 @@ func TestMachineAttribute(t *testing.T) {
 	code = `(define badMachine (docker "foo"))
 	(machineAttribute badMachine (machine (provider "Amazon")))`
 	runtimeErr(t, code,
-		fmt.Sprintf(`2: bad type, cannot change machine attributes: (docker "foo")`))
+		fmt.Sprintf(
+			`2: bad type, cannot change machine attributes: (docker "foo")`))
 
 	// Test setting range attributes
 	code = `(define machines (machine (provider "Amazon")))
@@ -674,7 +675,8 @@ func TestMachineAttribute(t *testing.T) {
 
 	// Test setting attributes from within a lambda
 	code = `(define machines (machine (provider "Amazon")))
-	(define makeLarge (lambda (machines) (machineAttribute machines (ram 16) (cpu 8))))
+	(define makeLarge
+		(lambda (machines) (machineAttribute machines (ram 16) (cpu 8))))
 	(makeLarge machines)`
 	expCode = `(list)
 	(list)
@@ -1003,8 +1005,10 @@ func TestEnv(t *testing.T) {
 			code, containerResult, expected))
 	}
 
-	runtimeErr(t, `(setEnv (docker "foo") 1 "value")`, "1: setEnv key must be a string: 1")
-	runtimeErr(t, `(setEnv (docker "foo") "key" 1)`, "1: setEnv value must be a string: 1")
+	runtimeErr(t,
+		`(setEnv (docker "foo") 1 "value")`, "1: setEnv key must be a string: 1")
+	runtimeErr(t,
+		`(setEnv (docker "foo") "key" 1)`, "1: setEnv value must be a string: 1")
 }
 
 func TestConnect(t *testing.T) {
@@ -1201,7 +1205,8 @@ func TestImport(t *testing.T) {
 	// Test import with an import
 	testFs = afero.NewMemMapFs()
 	util.AppFs = testFs
-	util.WriteFile("square.spec", []byte("(define Square (lambda (x) (* x x)))"), 0644)
+	util.WriteFile("square.spec", []byte("(define Square (lambda (x) (* x x)))"),
+		0644)
 	util.WriteFile("cube.spec", []byte(`(import "square")
 	(define Cube (lambda (x) (* x (square.Square x))))`), 0644)
 	parseTestImport(t, `(import "cube") (cube.Cube 2)`,

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -21,12 +21,14 @@ func TestToTar(t *testing.T) {
 
 	for tr := tar.NewReader(out); err != io.EOF; _, err = tr.Next() {
 		if err != nil {
-			t.Errorf("Error %#v while reading tar archive, expected nil", err.Error())
+			t.Errorf("Error %#v while reading tar archive, expected nil",
+				err.Error())
 		}
 
 		_, err = io.Copy(writer, tr)
 		if err != nil {
-			t.Errorf("Error %#v while reading tar archive, expected nil", err.Error())
+			t.Errorf("Error %#v while reading tar archive, expected nil",
+				err.Error())
 		}
 	}
 


### PR DESCRIPTION
rebased on master, reordering commits so "format: Rewrite our format checker in go" comes last.