### PR TITLE
cloud_config: Add bash header to swarm script

### DIFF
--- a/cluster/provider/cloud_config.go
+++ b/cluster/provider/cloud_config.go
@@ -38,7 +38,8 @@ initialize_docker() {
 
 	mkdir -p /etc/systemd/system/docker.service.d
 
-	echo "docker -H tcp://${PRIVATE_IPv4}:2377 \$@" > /usr/bin/swarm
+	echo '#!/bin/sh' > /usr/bin/swarm
+	echo "docker -H tcp://${PRIVATE_IPv4}:2377 \$@" >> /usr/bin/swarm
 	chmod 755 /usr/bin/swarm
 
 	cat <<- EOF > /etc/systemd/system/docker.service.d/override.conf


### PR DESCRIPTION
This patch adds "#!/bin/sh" to the swarm shortcut so that it can
be recognized as a valid script by Go's os/exec.