### PR TITLE
ovsdb: Redesign ovsdb with simplier interface and improved performance

### DIFF
--- a/minion/network/network.go
+++ b/minion/network/network.go
@@ -70,26 +70,27 @@ func runMaster(conn db.Conn) {
 		return
 	}
 
-	ovsdb, err := ovsdb.Open()
+	ovsdbClient, err := ovsdb.Open()
 	if err != nil {
 		log.WithError(err).Error("Failed to connect to OVSDB.")
 		return
 	}
-	defer ovsdb.Close()
+	defer ovsdbClient.Close()
 
-	ovsdb.CreateSwitch(lSwitch)
-	lportSlice, err := ovsdb.ListPorts(lSwitch)
+	ovsdbClient.CreateLogicalSwitch(lSwitch)
+	lports, err := ovsdbClient.ListLogicalPorts(lSwitch)
 	if err != nil {
 		log.WithError(err).Error("Failed to list OVN ports.")
 		return
 	}
 
-	// The garbageMap starts of containing every logical port in OVN.  As we find
+	// The garbageMap starts off containing every logical port in OVN.  As we find
 	// that these ports are still useful, they're deleted from garbageMap until only
-	// leftover garbage ports are remaining.  These are then deleted.
-	garbageMap := make(map[string]struct{})
-	for _, lport := range lportSlice {
-		garbageMap[lport.Name] = struct{}{}
+	// leftover garbage ports are remaining. These leftover logical ports are then
+	// deleted from ovsdb.
+	garbageMap := make(map[string]ovsdb.LPort)
+	for _, lport := range lports {
+		garbageMap[lport.Name] = lport
 	}
 
 	for _, dbl := range labels {
@@ -105,9 +106,10 @@ func runMaster(conn db.Conn) {
 		log.WithFields(log.Fields{
 			"IP": dbl.IP,
 		}).Info("New logical port.")
-		err := ovsdb.CreatePort(lSwitch, dbl.IP, labelMac, dbl.IP)
-		if err != nil {
-			log.WithError(err).Warnf("Failed to create port %s.", dbl.IP)
+
+		if err := ovsdbClient.CreateLogicalPort(lSwitch, dbl.Label, labelMac,
+			dbl.IP); err != nil {
+			log.WithError(err).Warnf("Failed to create port %s.", dbl.Label)
 		}
 	}
 
@@ -120,8 +122,9 @@ func runMaster(conn db.Conn) {
 		log.WithFields(log.Fields{
 			"IP": dbc.IP,
 		}).Info("New logical port.")
-		err := ovsdb.CreatePort("quilt", dbc.IP, dbc.Mac, dbc.IP)
-		if err != nil {
+
+		if err := ovsdbClient.CreateLogicalPort(lSwitch, dbc.IP, dbc.Mac,
+			dbc.IP); err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
 				"name":  dbc.IP,
@@ -131,9 +134,9 @@ func runMaster(conn db.Conn) {
 
 	// Ports still in the map don't have a corresponding label otherwise they would
 	// have been deleted in the preceding loop.
-	for lport := range garbageMap {
-		log.Infof("Delete logical port %s.", lport)
-		if err := ovsdb.DeletePort(lSwitch, lport); err != nil {
+	for _, lport := range garbageMap {
+		log.Infof("Delete logical port %s.", lport.Name)
+		if err := ovsdbClient.DeleteLogicalPort(lSwitch, lport); err != nil {
 			log.WithError(err).Warn("Failed to delete logical port.")
 		}
 	}
@@ -202,7 +205,7 @@ func updateACLs(connections []db.Connection, labels []db.Label,
 		}
 	}
 
-	acls := make(map[ovsdb.AclCore]struct{})
+	coreACLs := make(map[ovsdb.AclCore]struct{})
 
 	// Drop all ip traffic by default.
 	new := ovsdb.AclCore{
@@ -210,14 +213,14 @@ func updateACLs(connections []db.Connection, labels []db.Label,
 		Match:     "ip",
 		Action:    "drop",
 		Direction: "to-lport"}
-	acls[new] = struct{}{}
+	coreACLs[new] = struct{}{}
 
 	new = ovsdb.AclCore{
 		Priority:  0,
 		Match:     "ip",
 		Action:    "drop",
 		Direction: "from-lport"}
-	acls[new] = struct{}{}
+	coreACLs[new] = struct{}{}
 
 	for match := range matchSet {
 		new = ovsdb.AclCore{
@@ -225,34 +228,31 @@ func updateACLs(connections []db.Connection, labels []db.Label,
 			Direction: "to-lport",
 			Action:    "allow",
 			Match:     match}
-		acls[new] = struct{}{}
+		coreACLs[new] = struct{}{}
 
 		new = ovsdb.AclCore{
 			Priority:  1,
 			Direction: "from-lport",
 			Action:    "allow",
 			Match:     match}
-		acls[new] = struct{}{}
+		coreACLs[new] = struct{}{}
 	}
 
 	for _, acl := range ovsdbACLs {
 		core := acl.Core
-		if _, ok := acls[core]; ok {
-			delete(acls, core)
+		if _, ok := coreACLs[core]; ok {
+			delete(coreACLs, core)
 			continue
 		}
 
-		err := ovsdbClient.DeleteACL(lSwitch, core.Direction, core.Priority,
-			core.Match)
-		if err != nil {
+		if err := ovsdbClient.DeleteACL(lSwitch, acl); err != nil {
 			log.WithError(err).Warn("Error deleting ACL")
 		}
 	}
 
-	for acl := range acls {
-		err := ovsdbClient.CreateACL(lSwitch, acl.Direction, acl.Priority,
-			acl.Match, acl.Action, false)
-		if err != nil {
+	for aclCore := range coreACLs {
+		if err := ovsdbClient.CreateACL(lSwitch, aclCore.Direction,
+			aclCore.Priority, aclCore.Match, aclCore.Action); err != nil {
 			log.WithError(err).Warn("Error adding ACL")
 		}
 	}

--- a/minion/ovsdb/ovsdb.go
+++ b/minion/ovsdb/ovsdb.go
@@ -5,51 +5,66 @@ import (
 	"fmt"
 	"math"
 	"reflect"
-	"strings"
-	"time"
 
 	log "github.com/Sirupsen/logrus"
 	ovs "github.com/socketplane/libovsdb"
 )
 
-// The Ovsdb interface allows interaction with a locally running instance of the Open
-// vSwitchd database.
-type Ovsdb interface {
-	Close()
-	CreateSwitch(lswitch string) error
-	ListPorts(lswitch string) ([]LPort, error)
-	CreatePort(lswitch, name, mac, ip string) error
-	DeletePort(lswitch, name string) error
-	ListACLs(lswitch string) ([]Acl, error)
-	CreateACL(lswitch string, dir string, priority int, match string, action string,
-		doLog bool) error
-	DeleteACL(lswitch string, dir string, priority int, match string) error
-	DeleteOFPort(bridge, name string) error
-	GetOFPortNo(name string) (int, error)
-	CreateOFPort(bridge, name string) error
-	ListOFPorts(bridge string) ([]string, error)
-	GetDefaultOFInterface(port string) (Row, error)
-	GetOFInterfaceType(iface Row) (string, error)
-	GetOFInterfacePeer(iface Row) (string, error)
-	GetOFInterfaceAttachedMAC(iface Row) (string, error)
-	GetOFInterfaceIfaceID(iface Row) (string, error)
-	SetOFInterfacePeer(name, peer string) error
-	SetOFInterfaceAttachedMAC(name, mac string) error
-	SetOFInterfaceIfaceID(name, ifaceID string) error
-	SetOFInterfaceType(name, ifaceType string) error
-	SetBridgeMac(lswitch, mac string) error
+// This is simply a wrapper around all the libovsdb calls we are currently using. This
+// makes it very easy to mock for testing.
+type ovsdbAPI interface {
+	disconnect()
+	transact(db string, operation ...ovs.Operation) ([]ovs.OperationResult, error)
 }
 
 // Client is a connection to the ovsdb-server database.
 type Client struct {
+	ovsdbAPI
+}
+
+type ovsdbClient struct {
 	*ovs.OvsdbClient
+}
+
+func (client ovsdbClient) disconnect() {
+	client.Disconnect()
+}
+
+func (client ovsdbClient) transact(db string, operation ...ovs.Operation) (
+	[]ovs.OperationResult, error) {
+	return client.Transact(db, operation...)
 }
 
 // LPort is a logical port in OVN.
 type LPort struct {
+	uuid      ovs.UUID
 	Name      string
 	Addresses []string
 }
+
+// Interface is a logical interface in OVN.
+type Interface struct {
+	uuid        ovs.UUID
+	portUUID    ovs.UUID
+	Name        string
+	Peer        string
+	AttachedMAC string
+	IfaceID     string
+	Bridge      string
+	Type        string
+	OFPort      int
+}
+
+const (
+	// InterfaceTypePatch is the logical interface type `patch`
+	InterfaceTypePatch = "patch"
+
+	// InterfaceTypeInternal is the logical interface type `internal`
+	InterfaceTypeInternal = "internal"
+
+	// InterfaceTypeGeneve is the logical interface type `geneve`
+	InterfaceTypeGeneve = "geneve"
+)
 
 // Acl is a firewall rule in OVN.
 type Acl struct {
@@ -67,48 +82,547 @@ type AclCore struct {
 	Action    string
 }
 
-// ExistError is returned as a pointer (*ExistError) when what was searched
-// for does not exist
-type ExistError struct {
-	msg string
+type row map[string]interface{}
+type mutation interface{}
+
+// Base on RFC 7047, empty condition should return all rows from a table. However,
+// libovsdb does not seem to support that yet. This is the simplist, most common solution
+// to it.
+func noCondition() []interface{} {
+	return []interface{}{ovs.NewCondition("_uuid", "!=", ovs.UUID{GoUUID: "_"})}
 }
 
-// Row is an ovsdb row
-type Row map[string]interface{}
-type condition interface{}
-type mutation interface{}
+func newCondition(column, function string, value interface{}) []interface{} {
+	return []interface{}{ovs.NewCondition(column, function, value)}
+}
 
 // Open creates a new Ovsdb connection.
 // It's stored in a variable so we can mock it out for the unit tests.
-var Open = func() (Ovsdb, error) {
+var Open = func() (Client, error) {
 	client, err := ovs.Connect("127.0.0.1", 6640)
-	return Client{client}, err
+	return Client{ovsdbClient{client}}, err
 }
 
 // Close destroys an Ovsdb connection created by Open.
 func (ovsdb Client) Close() {
-	ovsdb.Disconnect()
+	ovsdb.disconnect()
 }
 
-// 'value' is normally a string, except under special conditions, upon which
-// this function should recognize them and deal with it appropriately
-func newCondition(column, function string, value interface{}) condition {
-	if column == "_uuid" {
-		switch t := value.(type) {
-		case ovs.UUID:
-			return ovs.NewCondition(column, function, value)
-		case string:
-			return ovs.NewCondition(column, function,
-				ovs.UUID{GoUUID: value.(string)})
-		default:
-			log.WithFields(log.Fields{
-				"value": value,
-				"type":  t,
-			}).Error("invalid type for value in condition")
-			return nil
+// CreateLogicalSwitch creates a new logical switch in OVN.
+func (ovsdb Client) CreateLogicalSwitch(lswitch string) error {
+	check, err := ovsdb.transact("OVN_Northbound", ovs.Operation{
+		Op:    "select",
+		Table: "Logical_Switch",
+		Where: newCondition("name", "==", lswitch),
+	})
+	if err != nil {
+		return fmt.Errorf("transaction error: listing logical switches: %s", err)
+	}
+	if len(check[0].Rows) > 0 {
+		return fmt.Errorf("logical switch %s already exists", lswitch)
+	}
+
+	insertOp := ovs.Operation{
+		Op:    "insert",
+		Table: "Logical_Switch",
+		Row:   map[string]interface{}{"name": lswitch},
+	}
+
+	results, err := ovsdb.transact("OVN_Northbound", insertOp)
+	if err != nil {
+		return fmt.Errorf("transaction error: creating switch %s: %s",
+			lswitch, err)
+	}
+	return errorCheck(results, 1)
+}
+
+// ListLogicalPorts lists the logical ports in OVN.
+func (ovsdb Client) ListLogicalPorts(lswitch string) ([]LPort, error) {
+	result := []LPort{}
+
+	switchReply, err := ovsdb.transact("OVN_Northbound", ovs.Operation{
+		Op:    "select",
+		Table: "Logical_Switch",
+		Where: noCondition(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transaction error: listing switches: %s", err)
+	}
+	if len(switchReply[0].Rows) == 0 {
+		return result, nil
+	}
+	logicalSwitch := switchReply[0].Rows[0]
+
+	portReply, err := ovsdb.transact("OVN_Northbound", ovs.Operation{
+		Op:    "select",
+		Table: "Logical_Port",
+		Where: noCondition(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transaction error: listing lports on %s: %s",
+			lswitch, err)
+	}
+	portMap := rowUUIDMap(portReply[0].Rows)
+
+	for _, portUUID := range ovsUUIDSetToSlice(logicalSwitch["ports"]) {
+		portrow, ok := portMap[portUUID]
+		if !ok {
+			return nil, fmt.Errorf("missing port %v", portUUID)
+		}
+
+		result = append(result, LPort{
+			uuid:      portUUID,
+			Name:      portrow["name"].(string),
+			Addresses: ovsStringSetToSlice(portrow["addresses"]),
+		})
+	}
+	return result, nil
+}
+
+// CreateLogicalPort creates a new logical port in OVN.
+func (ovsdb Client) CreateLogicalPort(lswitch, name, mac, ip string) error {
+	addrs, err := ovs.NewOvsSet([]string{fmt.Sprintf("%s %s", mac, ip)})
+	if err != nil {
+		return err
+	}
+
+	port := map[string]interface{}{"name": name, "addresses": addrs}
+
+	insertOp := ovs.Operation{
+		Op:       "insert",
+		Table:    "Logical_Port",
+		Row:      port,
+		UUIDName: "qlportadd",
+	}
+
+	mutateOp := ovs.Operation{
+		Op:    "mutate",
+		Table: "Logical_Switch",
+		Mutations: []interface{}{
+			newMutation("ports", "insert", ovs.UUID{GoUUID: "qlportadd"}),
+		},
+		Where: newCondition("name", "==", lswitch),
+	}
+
+	results, err := ovsdb.transact("OVN_Northbound", insertOp, mutateOp)
+	if err != nil {
+		return fmt.Errorf("transaction error: creating lport %s on %s: %s",
+			name, lswitch, err)
+	}
+
+	return errorCheck(results, 2)
+}
+
+// DeleteLogicalPort removes a logical port from OVN.
+func (ovsdb Client) DeleteLogicalPort(lswitch string, lport LPort) error {
+	deleteOp := ovs.Operation{
+		Op:    "delete",
+		Table: "Logical_Port",
+		Where: newCondition("_uuid", "==", lport.uuid),
+	}
+
+	mutateOp := ovs.Operation{
+		Op:        "mutate",
+		Table:     "Logical_Switch",
+		Mutations: []interface{}{newMutation("ports", "delete", lport.uuid)},
+		Where:     newCondition("name", "==", lswitch),
+	}
+
+	results, err := ovsdb.transact("OVN_Northbound", deleteOp, mutateOp)
+	if err != nil {
+		return fmt.Errorf("transaction error: deleting lport %s on %s: %s",
+			lport, lswitch, err)
+	}
+	return errorCheck(results, 2)
+}
+
+// ListACLs lists the access control rules in OVN.
+func (ovsdb Client) ListACLs(lswitch string) ([]Acl, error) {
+	result := []Acl{}
+
+	switchReply, err := ovsdb.transact("OVN_Northbound", ovs.Operation{
+		Op:    "select",
+		Table: "Logical_Switch",
+		Where: newCondition("name", "==", lswitch),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transaction error: retrieving lswitch %s: %s",
+			lswitch, err)
+	}
+	if len(switchReply[0].Rows) == 0 {
+		return result, nil
+	}
+	logicalSwitch := switchReply[0].Rows[0]
+
+	aclReply, err := ovsdb.transact("OVN_Northbound", ovs.Operation{
+		Op:    "select",
+		Table: "ACL",
+		Where: noCondition(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transaction error: listing ACLs on %s: %s",
+			lswitch, err)
+	}
+	aclMap := rowUUIDMap(aclReply[0].Rows)
+
+	for _, aclUUID := range ovsUUIDSetToSlice(logicalSwitch["acls"]) {
+		aclrow, ok := aclMap[aclUUID]
+		if !ok {
+			return nil, fmt.Errorf("missing ACL %v", aclUUID)
+		}
+
+		result = append(result, Acl{
+			uuid: aclUUID,
+			Core: AclCore{
+				Priority:  int(aclrow["priority"].(float64)),
+				Direction: aclrow["direction"].(string),
+				Match:     aclrow["match"].(string),
+				Action:    aclrow["action"].(string),
+			},
+			Log: aclrow["log"].(bool),
+		})
+	}
+	return result, nil
+}
+
+// CreateACL creates an access control rule in OVN.
+//
+// direction, unless wildcarded, must be either "from-lport" or "to-lport"
+//
+// priority, unless wildcarded, must be in [1,32767]
+//
+// match, unless wildcarded or empty, must be a valid OpenFlow expression
+//
+// action must be one of {"allow", "allow-related", "drop", "reject"}
+//
+// direction and match may be wildcarded by passing the value "*". priority may also
+// be wildcarded by passing a value less than 0.
+func (ovsdb Client) CreateACL(lswitch string, direction string, priority int,
+	match string, action string) error {
+	aclRow := map[string]interface{}{
+		"priority": int(math.Max(0.0, float64(priority))),
+		"action":   action,
+		"log":      false,
+	}
+	if direction != "*" {
+		aclRow["direction"] = direction
+	}
+	if match != "*" {
+		aclRow["match"] = match
+	}
+
+	insertOp := ovs.Operation{
+		Op:       "insert",
+		Table:    "ACL",
+		Row:      aclRow,
+		UUIDName: "qacladd",
+	}
+
+	mutateOp := ovs.Operation{
+		Op:    "mutate",
+		Table: "Logical_Switch",
+		Mutations: []interface{}{
+			newMutation("acls", "insert", ovs.UUID{GoUUID: "qacladd"}),
+		},
+		Where: newCondition("name", "==", lswitch),
+	}
+
+	results, err := ovsdb.transact("OVN_Northbound", insertOp, mutateOp)
+	if err != nil {
+		return fmt.Errorf("transaction error: creating ACL on %s: %s",
+			lswitch, err)
+	}
+	return errorCheck(results, 2)
+}
+
+// DeleteACL removes an access control rule from OVN.
+func (ovsdb Client) DeleteACL(lswitch string, ovsdbACL Acl) error {
+	deleteOp := ovs.Operation{
+		Op:    "delete",
+		Table: "ACL",
+		Where: newCondition("_uuid", "==", ovsdbACL.uuid),
+	}
+
+	mutateOp := ovs.Operation{
+		Op:    "mutate",
+		Table: "Logical_Switch",
+		Mutations: []interface{}{
+			newMutation("acls", "delete", ovsdbACL.uuid),
+		},
+		Where: newCondition("name", "==", lswitch),
+	}
+
+	results, err := ovsdb.transact("OVN_Northbound", deleteOp, mutateOp)
+	if err != nil {
+		return fmt.Errorf("transaction error: deleting ACL on %s: %s",
+			lswitch, err)
+	}
+	return errorCheck(results, 2)
+}
+
+// ListInterfaces gets all openflow interfaces.
+func (ovsdb Client) ListInterfaces() ([]Interface, error) {
+	bridgeReply, err := ovsdb.transact("Open_vSwitch", ovs.Operation{
+		Op:    "select",
+		Table: "Bridge",
+		Where: noCondition(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transaction error: listing Bridges: %s", err)
+	}
+
+	portReply, err := ovsdb.transact("Open_vSwitch", ovs.Operation{
+		Op:    "select",
+		Table: "Port",
+		Where: noCondition(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transaction error: listing Ports: %s", err)
+	}
+	portMap := rowUUIDMap(portReply[0].Rows)
+
+	ifaceReply, err := ovsdb.transact("Open_vSwitch", ovs.Operation{
+		Op:    "select",
+		Table: "Interface",
+		Where: noCondition(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("transaction error: listing ifaces: %s", err)
+	}
+	ifaceMap := rowUUIDMap(ifaceReply[0].Rows)
+
+	result := []Interface{}
+	for _, bridge := range bridgeReply[0].Rows {
+		bridgeName, ok := bridge["name"].(string)
+		if !ok {
+			return nil, errors.New("bridge missing its name")
+		}
+		for _, portUUID := range ovsUUIDSetToSlice(bridge["ports"]) {
+			port, ok := portMap[portUUID]
+			if !ok {
+				return nil, fmt.Errorf("missing port %v", portUUID)
+			}
+
+			for _, ifaceUUID := range ovsUUIDSetToSlice(port["interfaces"]) {
+				iface, ok := ifaceMap[ifaceUUID]
+				if !ok {
+					return nil, fmt.Errorf("missing interface %v",
+						ifaceUUID)
+				}
+
+				ifaceStruct, err := ifaceFromRow(iface)
+				if err != nil {
+					return nil, err
+				}
+
+				ifaceStruct.uuid = ifaceUUID
+				ifaceStruct.portUUID = portUUID
+				ifaceStruct.Bridge = bridgeName
+				result = append(result, ifaceStruct)
+			}
 		}
 	}
-	return ovs.NewCondition(column, function, value)
+
+	return result, nil
+}
+
+// CreateInterface creates an openflow port on specified bridge.
+//
+// A port cannot be created without an interface, that is why the "default"
+// interface (one with the same name as the port) is created along with it.
+func (ovsdb Client) CreateInterface(bridge, name string) error {
+	var ops []ovs.Operation
+
+	ops = append(ops, ovs.Operation{
+		Op:       "insert",
+		Table:    "Interface",
+		Row:      row{"name": name},
+		UUIDName: "qifaceadd",
+	})
+
+	ifaces, err := ovs.NewOvsSet([]ovs.UUID{{GoUUID: "qifaceadd"}})
+	if err != nil {
+		return err
+	}
+
+	ops = append(ops, ovs.Operation{
+		Op:       "insert",
+		Table:    "Port",
+		Row:      row{"name": name, "interfaces": ifaces},
+		UUIDName: "qportadd",
+	})
+
+	ops = append(ops, ovs.Operation{
+		Op:    "mutate",
+		Table: "Bridge",
+		Mutations: []interface{}{
+			newMutation("ports", "insert", ovs.UUID{GoUUID: "qportadd"}),
+		},
+		Where: newCondition("name", "==", bridge),
+	})
+
+	results, err := ovsdb.transact("Open_vSwitch", ops...)
+	if err != nil {
+		return fmt.Errorf("transaction error: creating interface %s: %s",
+			name, err)
+	}
+	return errorCheck(results, len(ops))
+}
+
+// DeleteInterface deletes an openflow interface.
+func (ovsdb Client) DeleteInterface(iface Interface) error {
+	deleteOp := ovs.Operation{
+		Op:    "delete",
+		Table: "Port",
+		Where: newCondition("name", "==", iface.Name),
+	}
+
+	mutateOp := ovs.Operation{
+		Op:    "mutate",
+		Table: "Bridge",
+		Mutations: []interface{}{
+			newMutation("ports", "delete", iface.portUUID),
+		},
+		Where: newCondition("name", "==", iface.Bridge),
+	}
+
+	results, err := ovsdb.transact("Open_vSwitch", deleteOp, mutateOp)
+	if err != nil {
+		return fmt.Errorf("transaction error: deleting interface %s: %s",
+			iface.Name, err)
+	}
+	return errorCheck(results, 2)
+}
+
+// ModifyInterface modifies the openflow interface.
+func (ovsdb Client) ModifyInterface(iface Interface) error {
+	var ops []ovs.Operation
+	var muts []mutation
+
+	if iface.Peer != "" {
+		muts = append(muts, newMutation("options", "insert",
+			map[string]string{"peer": iface.Peer}))
+	}
+
+	if iface.AttachedMAC != "" {
+		muts = append(muts, newMutation("external_ids", "insert",
+			map[string]string{"attached-mac": iface.AttachedMAC}))
+	}
+
+	if iface.IfaceID != "" {
+		muts = append(muts, newMutation("external_ids", "insert",
+			map[string]string{"iface-id": iface.IfaceID}))
+	}
+
+	if iface.Type == InterfaceTypePatch {
+		ops = append(ops, ovs.Operation{
+			Op:    "update",
+			Table: "Interface",
+			Where: newCondition("name", "==", iface.Name),
+			Row:   row{"type": "patch"},
+		})
+	}
+
+	for _, mut := range muts {
+		ops = append(ops, ovs.Operation{
+			Op:        "mutate",
+			Table:     "Interface",
+			Mutations: []interface{}{mut},
+			Where:     newCondition("name", "==", iface.Name),
+		})
+	}
+
+	if len(ops) == 0 {
+		return nil
+	}
+
+	results, err := ovsdb.transact("Open_vSwitch", ops...)
+	if err != nil {
+		return fmt.Errorf("transaction error: modifying interface %s: %s",
+			iface.Name, err)
+	}
+
+	return errorCheck(results, len(ops))
+}
+
+// SetBridgeMac sets the MAC address of the bridge.
+func (ovsdb Client) SetBridgeMac(bridge, mac string) error {
+	mut := newMutation("other_config", "insert", map[string]string{"hwaddr": mac})
+	mutateOp := ovs.Operation{
+		Op:        "mutate",
+		Table:     "Bridge",
+		Mutations: []interface{}{mut},
+		Where:     newCondition("name", "==", bridge),
+	}
+
+	results, err := ovsdb.transact("Open_vSwitch", mutateOp)
+	if err != nil {
+		return fmt.Errorf("transaction error: setting bridge %s's mac to %s: %s",
+			bridge, mac, err)
+	}
+	return errorCheck(results, 1)
+}
+
+func ifaceFromRow(row row) (Interface, error) {
+	iface := Interface{}
+
+	name, ok := row["name"].(string)
+	if !ok {
+		return iface, errors.New("missing Interface key: name")
+	}
+	iface.Name = name
+
+	ifaceType, ok := row["type"].(string)
+	if !ok {
+		return iface, errors.New("missing Interface key: type")
+	}
+	iface.Type = ifaceType
+
+	optRow, ok := row["options"]
+	if !ok {
+		return iface, errors.New("missing Interface key: options")
+	}
+	options, err := ovsStringMapToMap(optRow)
+	if err != nil {
+		return iface, err
+	}
+
+	extRow, ok := row["external_ids"]
+	if !ok {
+		return iface, errors.New("missing Interface key: external_ids")
+	}
+	externalIDs, err := ovsStringMapToMap(extRow)
+	if err != nil {
+		return iface, err
+	}
+
+	ofport, ok := row["ofport"].(int)
+	if !ok {
+		return iface, errors.New("missing Interface key: ofport")
+	}
+	iface.OFPort = ofport
+
+	// The following map keys could be missing without breaking the Schema in the
+	// Interface table.
+	if peer, ok := options["peer"]; ok {
+		iface.Peer = peer
+	} else {
+		log.Debug("missing Interface key: peer.")
+	}
+
+	if amac, ok := externalIDs["attached-mac"]; ok {
+		iface.AttachedMAC = amac
+	} else {
+		log.Debug("missing Interface key: attached-mac.")
+	}
+
+	if id, ok := externalIDs["iface-id"]; ok {
+		iface.IfaceID = id
+	} else {
+		log.Debug("missing Interface key: iface-id.")
+	}
+
+	return iface, nil
 }
 
 // This does not cover all cases, they should just be added as needed
@@ -116,11 +630,7 @@ func newMutation(column, mutator string, value interface{}) mutation {
 	switch typedValue := value.(type) {
 	case ovs.UUID:
 		uuidSlice := []ovs.UUID{typedValue}
-		mutateValue, err := ovs.NewOvsSet(uuidSlice)
-		if err != nil {
-			// An error can only occur if the input is not a slice
-			panic("newMutation(): an impossible error occurred")
-		}
+		mutateValue, _ := ovs.NewOvsSet(uuidSlice)
 		return ovs.NewMutation(column, mutator, mutateValue)
 	default:
 		var mutateValue interface{}
@@ -140,48 +650,6 @@ func newMutation(column, mutator string, value interface{}) mutation {
 		}
 		return ovs.NewMutation(column, mutator, mutateValue)
 	}
-}
-
-func (ovsdb Client) selectRows(db string, table string,
-	conds ...condition) ([]Row, error) {
-	var anonymousConds []interface{}
-	for _, c := range conds {
-		anonymousConds = append(anonymousConds, c)
-	}
-	selectOp := ovs.Operation{
-		Op:    "select",
-		Table: table,
-		Where: anonymousConds,
-	}
-	results, err := ovsdb.Transact(db, selectOp)
-	if err != nil {
-		return nil, err
-	}
-	var typedRows []Row
-	for _, r := range results[0].Rows {
-		typedRows = append(typedRows, r)
-	}
-	return typedRows, nil
-}
-
-func (ovsdb Client) getFromMapInRow(row Row, column, key string) (
-	interface{}, error) {
-	val, ok := row[column]
-	if !ok {
-		msg := fmt.Sprintf("column %s not found in row", column)
-		return nil, &ExistError{msg}
-	}
-	goMap, err := ovsStringMapToMap(val)
-	if err != nil {
-		return nil, err
-	}
-
-	val, ok = goMap[key]
-	if !ok {
-		msg := fmt.Sprintf("key %s not found in column %s", key, column)
-		return "", &ExistError{msg}
-	}
-	return val, nil
 }
 
 func ovsStringMapToMap(oMap interface{}) (map[string]string, error) {
@@ -244,602 +712,48 @@ func ovsUUIDSetToSlice(oSet interface{}) []ovs.UUID {
 	return ret
 }
 
-func errorCheck(results []ovs.OperationResult, expectedResponses int,
-	expectedCount int) error {
-	totalCount := 0
+func ovsUUIDFromRow(row row) ovs.UUID {
+	uuid := ovs.UUID{}
+	block, ok := row["_uuid"].([]interface{})
+	if !ok && len(block) != 2 {
+		// This should never happen.
+		panic("row does not have valid UUID")
+	}
+	uuid.GoUUID = block[1].(string)
+	return uuid
+}
+
+func rowUUIDMap(rows []map[string]interface{}) map[ovs.UUID]row {
+	res := map[ovs.UUID]row{}
+	for _, row := range rows {
+		uuid := ovsUUIDFromRow(row)
+		res[uuid] = row
+	}
+	return res
+}
+
+func errorCheck(results []ovs.OperationResult, expectedResponses int) error {
 	if len(results) < expectedResponses {
 		return errors.New("mismatched responses and operations")
 	}
 	for i, result := range results {
 		if result.Error != "" {
-			return fmt.Errorf("[%d] %s: %s", i, result.Error, result.Details)
-		}
-		totalCount += result.Count
-	}
-	if totalCount != expectedCount {
-		return errors.New("unexpected number of rows altered")
-	}
-	return nil
-}
-
-// CreateSwitch creates a new logical switch in OVN.
-func (ovsdb Client) CreateSwitch(lswitch string) error {
-	check, err := ovsdb.selectRows("OVN_Northbound", "Logical_Switch",
-		newCondition("name", "==", lswitch))
-	if err != nil {
-		return err
-	}
-	if len(check) > 0 {
-		return &ExistError{
-			fmt.Sprintf("logical switch %s already exists", lswitch),
-		}
-	}
-
-	bridge := make(map[string]interface{})
-	bridge["name"] = lswitch
-
-	insertOp := ovs.Operation{
-		Op:    "insert",
-		Table: "Logical_Switch",
-		Row:   bridge,
-	}
-
-	results, err := ovsdb.Transact("OVN_Northbound", insertOp)
-	if err != nil {
-		return errors.New("transaction error")
-	}
-	return errorCheck(results, 1, 2)
-}
-
-// ListPorts lists the logical ports in OVN.
-func (ovsdb Client) ListPorts(lswitch string) ([]LPort, error) {
-	var lports []LPort
-	results, err := ovsdb.selectRows("OVN_Northbound", "Logical_Switch",
-		newCondition("name", "==", lswitch))
-	if err != nil {
-		return nil, err
-	}
-	if len(results) <= 0 {
-		return lports, nil
-	}
-	ports := ovsUUIDSetToSlice(results[0]["ports"])
-	for _, result := range ports {
-		results, err = ovsdb.selectRows("OVN_Northbound", "Logical_Port",
-			newCondition("_uuid", "==", result.GoUUID))
-		if err != nil {
-			return nil, err
-		}
-		if len(results) <= 0 {
-			continue
-		}
-		lport := results[0]
-		port := LPort{
-			Name:      lport["name"].(string),
-			Addresses: ovsStringSetToSlice(results[0]["addresses"]),
-		}
-		lports = append(lports, port)
-	}
-	return lports, nil
-}
-
-// CreatePort creates a new logical port in OVN.
-func (ovsdb Client) CreatePort(lswitch, name, mac, ip string) error {
-	// OVN Uses name an index into the Logical_Port table so, we need to check
-	// no port called name already exists. This isn't strictly necessary, but it
-	// makes our lives easier.
-	rows, err := ovsdb.selectRows("OVN_Northbound", "Logical_Port",
-		newCondition("name", "==", name))
-	if err != nil {
-		return err
-	}
-	if len(rows) > 0 {
-		return &ExistError{fmt.Sprintf("port %s already exists", name)}
-	}
-
-	port := make(map[string]interface{})
-	port["name"] = name
-	addrs, err := ovs.NewOvsSet([]string{fmt.Sprintf("%s %s", mac, ip)})
-	if err != nil {
-		return err
-	}
-	port["addresses"] = addrs
-
-	insertOp := ovs.Operation{
-		Op:       "insert",
-		Table:    "Logical_Port",
-		Row:      port,
-		UUIDName: "dilportadd",
-	}
-
-	mutateOp := ovs.Operation{
-		Op:    "mutate",
-		Table: "Logical_Switch",
-		Mutations: []interface{}{
-			newMutation("ports", "insert", ovs.UUID{GoUUID: "dilportadd"}),
-		},
-		Where: []interface{}{newCondition("name", "==", lswitch)},
-	}
-
-	results, err := ovsdb.Transact("OVN_Northbound", insertOp, mutateOp)
-	if err != nil {
-		return errors.New("transaction error")
-	}
-	return errorCheck(results, 2, 1)
-}
-
-// DeletePort removes a logical port from OVN.
-func (ovsdb Client) DeletePort(lswitch, name string) error {
-	rows, err := ovsdb.selectRows("OVN_Northbound", "Logical_Port",
-		newCondition("name", "==", name))
-	if err != nil {
-		return err
-	}
-	if len(rows) == 0 {
-		return nil
-	}
-	uuid := ovs.UUID{GoUUID: rows[0]["_uuid"].([]interface{})[1].(string)}
-
-	deleteOp := ovs.Operation{
-		Op:    "delete",
-		Table: "Logical_Port",
-		Where: []interface{}{newCondition("_uuid", "==", uuid)},
-	}
-
-	mutateOp := ovs.Operation{
-		Op:        "mutate",
-		Table:     "Logical_Switch",
-		Mutations: []interface{}{newMutation("ports", "delete", uuid)},
-		Where:     []interface{}{newCondition("name", "==", lswitch)},
-	}
-
-	results, err := ovsdb.Transact("OVN_Northbound", deleteOp, mutateOp)
-	if err != nil {
-		return errors.New("transaction error")
-	}
-	return errorCheck(results, 2, 2)
-}
-
-// ListACLs lists the access control rules in OVN.
-func (ovsdb Client) ListACLs(lswitch string) ([]Acl, error) {
-	var acls []Acl
-	results, err := ovsdb.selectRows("OVN_Northbound", "Logical_Switch",
-		newCondition("name", "==", lswitch))
-	if err != nil {
-		return nil, err
-	}
-	if len(results) <= 0 {
-		return acls, nil
-	}
-	aids := ovsUUIDSetToSlice(results[0]["acls"])
-	for _, aid := range aids {
-		aid := aid.GoUUID
-		results, err := ovsdb.selectRows("OVN_Northbound", "ACL",
-			newCondition("_uuid", "==", aid))
-		if err != nil {
-			return nil, err
-		}
-		for _, result := range results {
-			goUUID := result["_uuid"].([]interface{})[1].(string)
-			acl := Acl{
-				uuid: ovs.UUID{GoUUID: goUUID},
-				Core: AclCore{
-					Priority:  int(result["priority"].(float64)),
-					Direction: result["direction"].(string),
-					Match:     result["match"].(string),
-					Action:    result["action"].(string),
-				},
-				Log: result["log"].(bool),
-			}
-			acls = append(acls, acl)
-		}
-	}
-	return acls, nil
-}
-
-// CreateACL creates an access control rule in OVN.
-//
-// The parameters to the CreatACL() and DeleteACL() functions correspond to columns
-// of the ACL table of the OVN database in the following ways:
-//
-// dir corresponds to the "direction" column and, unless wildcarded, must be
-// either "from-lport" or "to-lport"
-//
-// priority corresponds to the "priority" column and, unless wildcarded, must be
-// in [1,32767]
-//
-// match corresponds to the "match" column and, unless wildcarded or empty, must
-// be a valid OpenFlow expression
-//
-// action corresponds to the "action" column and must be one of the following
-// values in {"allow", "allow-related", "drop", "reject"}
-//
-// doLog corresponds to the "log" column
-//
-// dir and match may be wildcarded by passing the value "*". priority may also
-// be wildcarded by passing a value less than 0
-func (ovsdb Client) CreateACL(lswitch string, dir string, priority int, match string,
-	action string, doLog bool) error {
-	acl := make(map[string]interface{})
-	if dir != "*" {
-		acl["direction"] = dir
-	}
-	if match != "*" {
-		acl["match"] = match
-	}
-	acl["priority"] = int(math.Max(0.0, float64(priority)))
-	acl["action"] = action
-	acl["log"] = doLog
-
-	insertOp := ovs.Operation{
-		Op:       "insert",
-		Table:    "ACL",
-		Row:      acl,
-		UUIDName: "diacladd",
-	}
-
-	mutateOp := ovs.Operation{
-		Op:    "mutate",
-		Table: "Logical_Switch",
-		Mutations: []interface{}{
-			newMutation("acls", "insert", ovs.UUID{GoUUID: "diacladd"}),
-		},
-		Where: []interface{}{newCondition("name", "==", lswitch)},
-	}
-
-	results, err := ovsdb.Transact("OVN_Northbound", insertOp, mutateOp)
-	if err != nil {
-		return errors.New("transaction error")
-	}
-	return errorCheck(results, 2, 1)
-}
-
-// DeleteACL removes an access control rule from OVN.
-func (ovsdb Client) DeleteACL(lswitch string, dir string, priority int,
-	match string) error {
-	acls, err := ovsdb.ListACLs(lswitch)
-	if err != nil {
-		return err
-	}
-	for _, acl := range acls {
-		if dir != "*" && acl.Core.Direction != dir {
-			continue
-		}
-		if match != "*" && acl.Core.Match != match {
-			continue
-		}
-		if priority >= 0 && acl.Core.Priority != priority {
-			continue
-		}
-
-		deleteOp := ovs.Operation{
-			Op:    "delete",
-			Table: "ACL",
-			Where: []interface{}{newCondition("_uuid", "==", acl.uuid)},
-		}
-
-		mutateOp := ovs.Operation{
-			Op:    "mutate",
-			Table: "Logical_Switch",
-			Mutations: []interface{}{
-				newMutation("acls", "delete", acl.uuid),
-			},
-			Where: []interface{}{newCondition("name", "==", lswitch)},
-		}
-
-		results, err := ovsdb.Transact("OVN_Northbound", deleteOp, mutateOp)
-		if err != nil {
-			return errors.New("transaction error")
-		}
-		check := errorCheck(results, 2, 2)
-		if check != nil {
-			return check
+			return fmt.Errorf("operation %d failed due to error: %s: %s",
+				i, result.Error, result.Details)
 		}
 	}
 	return nil
 }
 
-func (ovsdb Client) getOFGeneric(table, name string) ([]Row, error) {
-	results, err := ovsdb.selectRows("Open_vSwitch", table,
-		newCondition("name", "==", name))
-	if err != nil {
-		return nil, err
-	}
-	if len(results) == 0 {
-		return nil, &ExistError{
-			fmt.Sprintf("no %s with name %s", strings.ToLower(table), name),
-		}
-	}
+// InterfaceSlice is used for HashJoin.
+type InterfaceSlice []Interface
 
-	return results, nil
+// Get is required for HashJoin.
+func (ovsps InterfaceSlice) Get(i int) interface{} {
+	return ovsps[i]
 }
 
-// DeleteOFPort deletes an openflow port with the corresponding bridge and
-// port names.
-func (ovsdb Client) DeleteOFPort(bridge, name string) error {
-	rows, err := ovsdb.selectRows("Open_vSwitch", "Port",
-		newCondition("name", "==", name))
-	if err != nil {
-		return err
-	}
-	if len(rows) == 0 {
-		return nil
-	}
-
-	deleteOp := ovs.Operation{
-		Op:    "delete",
-		Table: "Port",
-		Where: []interface{}{newCondition("name", "==", name)},
-	}
-
-	uuid := ovs.UUID{GoUUID: rows[0]["_uuid"].([]interface{})[1].(string)}
-	mutateOp := ovs.Operation{
-		Op:        "mutate",
-		Table:     "Bridge",
-		Mutations: []interface{}{newMutation("ports", "delete", uuid)},
-		Where:     []interface{}{newCondition("name", "==", bridge)},
-	}
-
-	results, err := ovsdb.Transact("Open_vSwitch", deleteOp, mutateOp)
-	if err != nil {
-		return errors.New("transaction error")
-	}
-	return errorCheck(results, 2, 2)
-}
-
-// GetOFPortNo retrieves the OpenFlow port number of 'name' from OVS.
-//
-// Returns an error of type *ExistError if the port does not exist
-func (ovsdb Client) GetOFPortNo(name string) (int, error) {
-	// It takes some time for the OF port to get up, so we give
-	// it a few chances, before we return an error.
-	for i := 0; i < 3; i++ {
-		results, err := ovsdb.getOFGeneric("Interface", name)
-		if err != nil {
-			return 0, err
-		}
-
-		if port, ok := results[0]["ofport"].(float64); ok {
-			return int(port), nil
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	return 0, &ExistError{fmt.Sprintf("interface %s has no openflow port", name)}
-}
-
-// CreateOFPort creates an openflow port on specified bridge
-//
-// A port cannot be created without an interface, that is why the "default"
-// interface (one with the same name as the port) is created along with it.
-func (ovsdb Client) CreateOFPort(bridge, name string) error {
-	var ops []ovs.Operation
-
-	ops = append(ops, ovs.Operation{
-		Op:       "insert",
-		Table:    "Interface",
-		Row:      Row{"name": name},
-		UUIDName: "diifaceadd",
-	})
-
-	ifaces, err := ovs.NewOvsSet([]ovs.UUID{{GoUUID: "diifaceadd"}})
-	if err != nil {
-		return err
-	}
-
-	ops = append(ops, ovs.Operation{
-		Op:       "insert",
-		Table:    "Port",
-		Row:      Row{"name": name, "interfaces": ifaces},
-		UUIDName: "diportadd",
-	})
-
-	ops = append(ops, ovs.Operation{
-		Op:    "mutate",
-		Table: "Bridge",
-		Mutations: []interface{}{
-			newMutation("ports", "insert", ovs.UUID{GoUUID: "diportadd"}),
-		},
-		Where: []interface{}{newCondition("name", "==", bridge)},
-	})
-
-	results, err := ovsdb.Transact("Open_vSwitch", ops...)
-	if err != nil {
-		return fmt.Errorf(
-			"transaction error creating openflow port %s within %s: %s",
-			name, bridge, err)
-	}
-	if err := errorCheck(results, 2, 1); err != nil {
-		return fmt.Errorf("error creating openflow port %s within %s: %s",
-			name, bridge, err)
-	}
-	return nil
-}
-
-// ListOFPorts lists all openflow ports on specified bridge
-func (ovsdb Client) ListOFPorts(bridge string) ([]string, error) {
-	var ports []string
-	results, err := ovsdb.selectRows("Open_vSwitch", "Bridge",
-		newCondition("name", "==", bridge))
-	if err != nil {
-		return nil, err
-	}
-	if len(results) == 0 {
-		return []string{}, nil
-	}
-	portUUIDs := ovsUUIDSetToSlice(results[0]["ports"])
-	for _, uuid := range portUUIDs {
-		results, err = ovsdb.selectRows("Open_vSwitch", "Port",
-			newCondition("_uuid", "==", uuid.GoUUID))
-		if err != nil {
-			return nil, err
-		}
-		ports = append(ports, results[0]["name"].(string))
-	}
-	return ports, nil
-}
-
-// GetDefaultOFInterface gets the default interface of the specified port,
-// which is the interface with the same name
-func (ovsdb Client) GetDefaultOFInterface(port string) (Row, error) {
-	results, err := ovsdb.selectRows("Open_vSwitch", "Port",
-		newCondition("name", "==", port))
-	if err != nil {
-		return nil, err
-	}
-	if len(results) == 0 {
-		return nil, fmt.Errorf("could not find openflow port %s", port)
-	}
-	ifaceUUIDs := ovsUUIDSetToSlice(results[0]["interfaces"])
-	for _, uuid := range ifaceUUIDs {
-		results, err = ovsdb.selectRows("Open_vSwitch", "Interface",
-			newCondition("_uuid", "==", uuid.GoUUID))
-		if err != nil {
-			return nil, err
-		}
-		row := results[0]
-		if row["name"].(string) == port {
-			return row, nil
-		}
-	}
-	err = fmt.Errorf("could not find default openflow interface for port %s",
-		port)
-	return nil, err
-}
-
-// GetOFInterfaceType gets the type of the interface given a Row
-func (ovsdb Client) GetOFInterfaceType(iface Row) (string, error) {
-	val, ok := iface["type"]
-	if !ok {
-		return "", &ExistError{"column type not found in interface row"}
-	}
-	return val.(string), nil
-}
-
-// GetOFInterfacePeer gets the peer of the interface given a Row
-func (ovsdb Client) GetOFInterfacePeer(iface Row) (string, error) {
-	val, err := ovsdb.getFromMapInRow(iface, "options", "peer")
-	if err != nil {
-		return "", err
-	}
-	return val.(string), nil
-}
-
-// GetOFInterfaceAttachedMAC gets the attached-mac of the interface given a Row
-func (ovsdb Client) GetOFInterfaceAttachedMAC(iface Row) (string, error) {
-	val, err := ovsdb.getFromMapInRow(iface, "external_ids", "attached-mac")
-	if err != nil {
-		return "", err
-	}
-	return val.(string), nil
-}
-
-// GetOFInterfaceIfaceID gets the iface-id of the interface given a Row
-func (ovsdb Client) GetOFInterfaceIfaceID(iface Row) (string, error) {
-	val, err := ovsdb.getFromMapInRow(iface, "external_ids", "iface-id")
-	if err != nil {
-		return "", err
-	}
-	return val.(string), nil
-}
-
-func (ovsdb Client) addToOFInterface(name string, mut mutation) error {
-	mutateOp := ovs.Operation{
-		Op:        "mutate",
-		Table:     "Interface",
-		Mutations: []interface{}{mut},
-		Where:     []interface{}{newCondition("name", "==", name)},
-	}
-
-	results, err := ovsdb.Transact("Open_vSwitch", mutateOp)
-	if err != nil {
-		return fmt.Errorf("transaction error inserting into interface %s: %s",
-			name, err)
-	}
-	return errorCheck(results, 1, 1)
-}
-
-func (ovsdb Client) updateOFInterface(name string, update Row) error {
-	updateOp := ovs.Operation{
-		Op:    "update",
-		Table: "Interface",
-		Where: []interface{}{newCondition("name", "==", name)},
-		Row:   update,
-	}
-
-	results, err := ovsdb.Transact("Open_vSwitch", updateOp)
-	if err != nil {
-		return fmt.Errorf("transaction error updating interface %s: %s",
-			name, err)
-	}
-	return errorCheck(results, 1, 1)
-}
-
-// SetOFInterfacePeer sets the peer of the interface
-func (ovsdb Client) SetOFInterfacePeer(name, peer string) error {
-	mut := newMutation("options", "insert", map[string]string{"peer": peer})
-	if err := ovsdb.addToOFInterface(name, mut); err != nil {
-		return fmt.Errorf("error setting interface %s to peer %s: %s",
-			name, peer, err)
-	}
-	return nil
-}
-
-// SetBridgeMac sets the MAC address of the bridge
-func (ovsdb Client) SetBridgeMac(lswitch, mac string) error {
-	mut := newMutation("other_config", "insert", map[string]string{"hwaddr": mac})
-	mutateOp := ovs.Operation{
-		Op:        "mutate",
-		Table:     "Bridge",
-		Mutations: []interface{}{mut},
-		Where:     []interface{}{newCondition("name", "==", lswitch)},
-	}
-
-	results, err := ovsdb.Transact("Open_vSwitch", mutateOp)
-	if err != nil {
-		return fmt.Errorf("transaction error changing MAC of bridge %s: %s",
-			lswitch, err)
-	}
-	return errorCheck(results, 1, 1)
-}
-
-// SetOFInterfaceAttachedMAC sets the attached-mac of the interface
-func (ovsdb Client) SetOFInterfaceAttachedMAC(name, mac string) error {
-	mut := newMutation("external_ids", "insert",
-		map[string]string{"attached-mac": mac})
-	if err := ovsdb.addToOFInterface(name, mut); err != nil {
-		return fmt.Errorf("error setting interface %s to attached-mac %s: %s",
-			name, mac, err)
-	}
-	return nil
-}
-
-// SetOFInterfaceIfaceID sets the iface-id of the interface
-func (ovsdb Client) SetOFInterfaceIfaceID(name, ifaceID string) error {
-	mut := newMutation("external_ids", "insert",
-		map[string]string{"iface-id": ifaceID})
-	if err := ovsdb.addToOFInterface(name, mut); err != nil {
-		return fmt.Errorf("error setting interface %s to iface-id %s: %s",
-			name, ifaceID, err)
-	}
-	return nil
-}
-
-// SetOFInterfaceType sets the type of the interface
-func (ovsdb Client) SetOFInterfaceType(name, ifaceType string) error {
-	if err := ovsdb.updateOFInterface(name, Row{"type": ifaceType}); err != nil {
-		return fmt.Errorf("error setting interface %s to type %s: %s",
-			name, ifaceType, err)
-	}
-	return nil
-}
-
-// Error returns the error message
-func (e *ExistError) Error() string {
-	return e.msg
-}
-
-// IsExist checks if the error is of type *ExistError
-func IsExist(e error) bool {
-	_, ok := e.(*ExistError)
-	return ok
+// Len is required for HashJoin.
+func (ovsps InterfaceSlice) Len() int {
+	return len(ovsps)
 }

--- a/minion/ovsdb/ovsdb_mock.go
+++ b/minion/ovsdb/ovsdb_mock.go
@@ -1,0 +1,441 @@
+package ovsdb
+
+import (
+	"reflect"
+
+	uuid "github.com/satori/go.uuid"
+	ovs "github.com/socketplane/libovsdb"
+)
+
+// NewFakeOvsdbClient returns an ovsdb client with mocked ovsdb.
+func NewFakeOvsdbClient() Client {
+	// Clears uuidMap for new test.
+	uuidMap = map[string]string{}
+
+	return Client{fakeOvsdbClient{
+		databases: map[string]fakeDb{},
+	}}
+}
+
+// Default OFPort used during creation of interface.
+const defaultOFPort = 123
+
+type fakeOvsdbClient struct {
+	databases map[string]fakeDb
+}
+
+type fakeDb struct {
+	tables map[string]fakeTable
+}
+
+type fakeTable struct {
+	rows map[string]fakeRow
+}
+
+type fakeRow map[string]interface{}
+
+// Mapping of UUIDName:UUID.
+var uuidMap map[string]string
+
+type fakeCondition struct {
+	column, function, value string
+}
+
+func (cond fakeCondition) matches(row fakeRow) bool {
+	toMatch := ""
+
+	switch v := row[cond.column].(type) {
+	case string:
+		toMatch = v
+	case []interface{}:
+		if cond.column == "_uuid" {
+			toMatch = v[1].(string)
+		} else {
+			panic("condition on this column is not yet supported: " +
+				cond.column)
+		}
+	default:
+		panic("condition type is not yet supported:" +
+			reflect.TypeOf(row[cond.column]).String())
+	}
+
+	switch cond.function {
+	case "==":
+		return toMatch == cond.value
+	case "!=":
+		return toMatch != cond.value
+	default:
+		panic("condition func is not yet supported: " + cond.function)
+	}
+}
+
+type fakeMutation struct {
+	column  string
+	mutator string
+	value   interface{}
+}
+
+// Applies mutation on a row, and returns number of mutations applied.
+func (mutation fakeMutation) apply(row *fakeRow) int {
+	mutationCount := 0
+	column := (*row)[mutation.column].([]interface{})
+
+	switch mutationVal := mutation.value.(type) {
+	case *ovs.OvsSet:
+		data := column[1].([]interface{})
+
+		uuidGeneric := mutationVal.GoSet[0].(ovs.UUID).GoUUID
+		uuid, ok := uuidMap[uuidGeneric]
+		if !ok {
+			uuid = uuidGeneric
+		}
+		switch mutation.mutator {
+		case "insert":
+			data = append(data, []interface{}{"uuid", uuid})
+			mutationCount++
+		case "delete":
+			for i, e := range data {
+				if e.([]interface{})[1] == uuid {
+					data = append(data[:i], data[i+1:]...)
+				}
+				i--
+			}
+			mutationCount++
+		default:
+			panic("mutator is not yet supported:" + mutation.mutator)
+		}
+		column[1] = data
+	case *ovs.OvsMap:
+		switch data := column[1].(type) {
+		case map[string]interface{}:
+			for k, v := range mutationVal.GoMap {
+				switch mutation.mutator {
+				case "insert":
+					data[k.(string)] = v
+					mutationCount++
+				default:
+					panic("mutator is not yet supported:" +
+						mutation.mutator)
+				}
+			}
+			column[1] = data
+		case []interface{}:
+			for k, v := range mutationVal.GoMap {
+				switch mutation.mutator {
+				case "insert":
+					data = append(data, []interface{}{k, v})
+					mutationCount++
+				default:
+					panic("mutator is not yet supported:" +
+						mutation.mutator)
+				}
+			}
+			column[1] = data
+		default:
+			panic("not yet supported.")
+		}
+	default:
+		panic("mutation type is not yet supported:" +
+			reflect.TypeOf(mutationVal).String())
+	}
+
+	(*row)[mutation.column] = column
+	return mutationCount
+}
+
+func (client fakeOvsdbClient) disconnect() {
+	// Nothing.
+}
+
+func (client fakeOvsdbClient) transact(database string, operation ...ovs.Operation) (
+	[]ovs.OperationResult, error) {
+	opResults := []ovs.OperationResult{}
+	for _, op := range operation {
+		var result ovs.OperationResult
+		var err error
+		switch op.Op {
+		case "insert":
+			result, err = client.insertOp(database, op)
+		case "select":
+			result, err = client.selectOp(database, op)
+		case "update":
+			result, err = client.updateOp(database, op)
+		case "mutate":
+			result, err = client.mutateOp(database, op)
+		case "delete":
+			result, err = client.deleteOp(database, op)
+		case "wait":
+			panic("operation is not yet supported: wait")
+		case "commit":
+			panic("operation is not yet supported: commit")
+		case "abort":
+			panic("operation is not yet supported: abort")
+		case "comment":
+			panic("operation is not yet supported: comment")
+		case "assert":
+			panic("operation is not yet supported: assert")
+		default:
+			panic("operation is not supported in RFC 7047:" + op.Op)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+		opResults = append(opResults, result)
+	}
+
+	return opResults, nil
+}
+
+// Only support insert single row for now.
+// RFC 7047: insert operation returns field UUID only.
+func (client fakeOvsdbClient) insertOp(database string, op ovs.Operation) (
+	ovs.OperationResult, error) {
+	db, ok := client.databases[database]
+	if !ok {
+		db = fakeDb{
+			tables: map[string]fakeTable{},
+		}
+	}
+
+	table, ok := db.tables[op.Table]
+	if !ok {
+		table = fakeTable{
+			rows: map[string]fakeRow{},
+		}
+	}
+
+	uuid := uuid.NewV4().String()
+	row := fakeRow{}
+	row["_uuid"] = []interface{}{"uuid", uuid}
+
+	for newKey, newVal := range op.Row {
+		switch v := newVal.(type) {
+		case string:
+			row[newKey] = newVal
+		case *ovs.OvsSet:
+			switch val := v.GoSet[0].(type) {
+			case string:
+				row[newKey] = val
+			case ovs.UUID:
+				uuidToAdd := ""
+				uuidGeneric := v.GoSet[0].(ovs.UUID).GoUUID
+				if actualUUID, ok := uuidMap[uuidGeneric]; ok {
+					uuidToAdd = actualUUID
+				} else {
+					uuidToAdd = uuidGeneric
+				}
+				row[newKey] = []interface{}{"set",
+					[]interface{}{[]interface{}{"uuid", uuidToAdd}}}
+			default:
+				panic("not yet supported: " +
+					reflect.TypeOf(v.GoSet[0]).String())
+			}
+		case int:
+			row[newKey] = float64(newVal.(int))
+		case bool:
+			row[newKey] = newVal
+		default:
+			panic("insert value type is not yet supported: " +
+				reflect.TypeOf(v).String())
+		}
+	}
+
+	// Mimic ovsdb's behavior of adding default fields for each table.
+	switch op.Table {
+	case "Logical_Switch":
+		row["ports"] = []interface{}{"set", []interface{}{}}
+		row["acls"] = []interface{}{"set", []interface{}{}}
+	case "Bridge":
+		row["ports"] = []interface{}{"set", []interface{}{}}
+		row["other_config"] = []interface{}{"map", map[string]interface{}{}}
+	case "Interface":
+		row["type"] = ""
+		row["options"] = []interface{}{"map", []interface{}{}}
+		row["external_ids"] = []interface{}{"map", []interface{}{}}
+		// An ofport is assigned to interface during creation.
+		row["ofport"] = defaultOFPort
+	}
+
+	table.rows[uuid] = row
+
+	// Update UUIDName if existed.
+	if op.UUIDName != "" {
+		uuidMap[op.UUIDName] = uuid
+	}
+
+	// Update table and db.
+	db.tables[op.Table] = table
+	client.databases[database] = db
+
+	return ovs.OperationResult{UUID: ovs.UUID{GoUUID: uuid}}, nil
+}
+
+// RFC 7047: select operation returns field rows only.
+func (client fakeOvsdbClient) selectOp(database string, op ovs.Operation) (
+	ovs.OperationResult, error) {
+	db, ok := client.databases[database]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	table, ok := db.tables[op.Table]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	result := ovs.OperationResult{}
+Outer:
+	for _, row := range table.rows {
+		conditions := parseOperationCondition(op)
+		for _, cond := range conditions {
+			if !cond.matches(row) {
+				continue Outer
+			}
+		}
+		result.Rows = append(result.Rows, row)
+	}
+	return result, nil
+}
+
+// RFC 7047: update operation returns field count only.
+func (client fakeOvsdbClient) updateOp(database string, op ovs.Operation) (
+	ovs.OperationResult, error) {
+	db, ok := client.databases[database]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	table, ok := db.tables[op.Table]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	updateCount := 0
+Outer:
+	for _, row := range table.rows {
+		conditions := parseOperationCondition(op)
+		for _, cond := range conditions {
+			if !cond.matches(row) {
+				continue Outer
+			}
+		}
+		for k, v := range op.Row {
+			row[k] = v
+			updateCount++
+		}
+	}
+	return ovs.OperationResult{Count: updateCount}, nil
+}
+
+// RFC 7047: select operation returns field count only.
+func (client fakeOvsdbClient) mutateOp(database string, op ovs.Operation) (
+	ovs.OperationResult, error) {
+	db, ok := client.databases[database]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	table, ok := db.tables[op.Table]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	mutations := parseOperationMutations(op)
+	mutationCount := 0
+
+Outer:
+	for rowUUID, row := range table.rows {
+		conditions := parseOperationCondition(op)
+		for _, cond := range conditions {
+			if !cond.matches(row) {
+				continue Outer
+			}
+		}
+		for _, mutation := range mutations {
+			mutation.apply(&row)
+			mutationCount++
+		}
+		table.rows[rowUUID] = row
+	}
+
+	// Update table and db.
+	db.tables[op.Table] = table
+	client.databases[database] = db
+
+	return ovs.OperationResult{Count: mutationCount}, nil
+}
+
+// RFC 7047: delete operation returns field count only.
+func (client fakeOvsdbClient) deleteOp(database string, op ovs.Operation) (
+	ovs.OperationResult, error) {
+	db, ok := client.databases[database]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	table, ok := db.tables[op.Table]
+	if !ok {
+		return ovs.OperationResult{}, nil
+	}
+
+	mutationCount := 0
+
+Outer:
+	for uuid, row := range table.rows {
+		conditions := parseOperationCondition(op)
+		for _, cond := range conditions {
+			if !cond.matches(row) {
+				continue Outer
+			}
+		}
+		delete(table.rows, uuid)
+		mutationCount++
+	}
+
+	// Update table and db.
+	db.tables[op.Table] = table
+	client.databases[database] = db
+
+	return ovs.OperationResult{Count: mutationCount}, nil
+}
+
+func parseOperationCondition(op ovs.Operation) []fakeCondition {
+	conditions := []fakeCondition{}
+	for _, condGeneric := range op.Where {
+		condition := condGeneric.([]interface{})
+		column := condition[0].(string)
+		function := condition[1].(string)
+		value := ""
+
+		switch v := condition[2].(type) {
+		case ovs.UUID:
+			value = v.GoUUID
+		case string:
+			value = v
+		default:
+			panic("parse condition is not yet supported:" +
+				reflect.TypeOf(condition[2]).String())
+		}
+
+		conditions = append(conditions, fakeCondition{
+			column:   column,
+			function: function,
+			value:    value,
+		})
+	}
+	return conditions
+}
+
+func parseOperationMutations(op ovs.Operation) []fakeMutation {
+	mutations := []fakeMutation{}
+	for _, mutGeneric := range op.Mutations {
+		mutation := mutGeneric.([]interface{})
+		mutations = append(mutations, fakeMutation{
+			column:  mutation[0].(string),
+			mutator: mutation[1].(string),
+			value:   mutation[2],
+		})
+	}
+	return mutations
+}

--- a/minion/ovsdb/ovsdb_test.go
+++ b/minion/ovsdb/ovsdb_test.go
@@ -1,10 +1,499 @@
 package ovsdb
 
-import "testing"
+import (
+	"fmt"
+	"reflect"
+	"testing"
 
-func TestNewCondition(t *testing.T) {
-	cond := newCondition("col", "func", "test")
-	if len(cond.([]interface{})) != 3 {
-		t.Error("Condition should have length 3.")
+	"github.com/NetSys/quilt/join"
+	ovs "github.com/socketplane/libovsdb"
+)
+
+func TestCreateLogicalSwitch(t *testing.T) {
+	ovsdbClient := NewFakeOvsdbClient()
+
+	// Create new switch.
+	lswitch := "test-switch"
+	if err := ovsdbClient.CreateLogicalSwitch(lswitch); err != nil {
+		t.Error(err)
 	}
+
+	// Check existence of created switch.
+	switchReply, err := ovsdbClient.transact("OVN_Northbound", ovs.Operation{
+		Op:    "select",
+		Table: "Logical_Switch",
+		Where: newCondition("name", "==", lswitch),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(switchReply[0].Rows) != 1 {
+		t.Error("logical switch creation failed")
+	}
+
+	// Try to create the same switch. Should now return error since it exists.
+	if err := ovsdbClient.CreateLogicalSwitch(lswitch); err == nil {
+		t.Error("create duplicate switch did not yield an error")
+	}
+}
+
+func TestLogicalPorts(t *testing.T) {
+	ovsdbClient := NewFakeOvsdbClient()
+
+	scoreFun := func(left, right interface{}) int {
+		ovsdbPort := left.(LPort)
+		localPort := right.(LPort)
+
+		switch {
+		case ovsdbPort.Name != localPort.Name:
+			return -1
+		case !reflect.DeepEqual(ovsdbPort.Addresses,
+			localPort.Addresses):
+			return -1
+		default:
+			return 0
+		}
+	}
+
+	checkCorrectness := func(ovsdbLPorts []LPort, localLPorts ...LPort) {
+		pair, _, _ := join.Join(ovsdbLPorts, localLPorts, scoreFun)
+		if len(pair) != len(localLPorts) {
+			t.Error("Local LPort do not match ovsdb LPorts.")
+		}
+	}
+
+	// Create new switch.
+	lswitch := "test-switch"
+	if err := ovsdbClient.CreateLogicalSwitch(lswitch); err != nil {
+		t.Error(err)
+	}
+
+	// Nothing happens yet. It should have zero logical port to be listed.
+	ovsdbLPorts, err := ovsdbClient.ListLogicalPorts(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbLPorts) != 0 {
+		t.Errorf("expected 0 logical port. Got %d instead.", len(ovsdbLPorts))
+	}
+
+	// Create logical port.
+	name1, mac1, ip1 := "lp1", "00:00:00:00:00:00", "0.0.0.0"
+	lport1 := LPort{
+		Name:      "lp1",
+		Addresses: []string{fmt.Sprintf("%s %s", mac1, ip1)},
+	}
+	if err := ovsdbClient.CreateLogicalPort(lswitch, name1, mac1, ip1); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have one logical port to be listed.
+	ovsdbLPorts, err = ovsdbClient.ListLogicalPorts(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbLPorts) != 1 {
+		t.Errorf("expected 1 logical port. Got %d instead.", len(ovsdbLPorts))
+	}
+	ovsdbLPort1 := ovsdbLPorts[0]
+
+	checkCorrectness(ovsdbLPorts, lport1)
+
+	// Create a second logical port.
+	name2, mac2, ip2 := "lp2", "00:00:00:00:00:01", "0.0.0.1"
+	lport2 := LPort{
+		Name:      "lp2",
+		Addresses: []string{fmt.Sprintf("%s %s", mac2, ip2)},
+	}
+	if err := ovsdbClient.CreateLogicalPort(lswitch, name2, mac2, ip2); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have two logical ports to be listed.
+	ovsdbLPorts, err = ovsdbClient.ListLogicalPorts(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbLPorts) != 2 {
+		t.Errorf("expected 2 logical port. Got %d instead.", len(ovsdbLPorts))
+	}
+
+	checkCorrectness(ovsdbLPorts, lport1, lport2)
+
+	// Delete the first logical port.
+	if err := ovsdbClient.DeleteLogicalPort(lswitch, ovsdbLPort1); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have one logical port to be listed.
+	ovsdbLPorts, err = ovsdbClient.ListLogicalPorts(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbLPorts) != 1 {
+		t.Errorf("expected 1 logical port. Got %d instead.", len(ovsdbLPorts))
+	}
+	ovsdbLPort2 := ovsdbLPorts[0]
+
+	checkCorrectness(ovsdbLPorts, lport2)
+
+	// Delete the last one as well.
+	if err := ovsdbClient.DeleteLogicalPort(lswitch, ovsdbLPort2); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have one logical port to be listed.
+	ovsdbLPorts, err = ovsdbClient.ListLogicalPorts(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbLPorts) != 0 {
+		t.Errorf("expected 0 logical port. Got %d instead.", len(ovsdbLPorts))
+	}
+}
+
+func TestACLs(t *testing.T) {
+	ovsdbClient := NewFakeOvsdbClient()
+
+	key := func(val interface{}) interface{} {
+		return val.(Acl).Core
+	}
+
+	checkCorrectness := func(ovsdbACLs []Acl, localACLs ...Acl) {
+		pair, _, _ := join.HashJoin(AclSlice(ovsdbACLs), AclSlice(localACLs),
+			key, key)
+		if len(pair) != len(localACLs) {
+			t.Error("Local ACLs do not match ovsdbACLs.")
+		}
+	}
+
+	// Create new switch.
+	lswitch := "test-switch"
+	if err := ovsdbClient.CreateLogicalSwitch(lswitch); err != nil {
+		t.Error(err)
+	}
+
+	// Create one ACL rule.
+	localCore1 := AclCore{
+		Priority:  1,
+		Direction: "from-lport",
+		Match:     "0.0.0.0",
+		Action:    "allow",
+	}
+
+	localACL1 := Acl{
+		Core: localCore1,
+		Log:  false,
+	}
+
+	if err := ovsdbClient.CreateACL(lswitch, localCore1.Direction,
+		localCore1.Priority, localCore1.Match, localCore1.Action); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have one ACL entry to be listed.
+	ovsdbACLs, err := ovsdbClient.ListACLs(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbACLs) != 1 {
+		t.Errorf("expected 1 ACL entry. Got %d instead.", len(ovsdbACLs))
+	}
+	ovsdbACL1 := ovsdbACLs[0]
+
+	checkCorrectness(ovsdbACLs, localACL1)
+
+	// Create one more ACL rule.
+	localCore2 := AclCore{
+		Priority:  2,
+		Direction: "from-lport",
+		Match:     "0.0.0.1",
+		Action:    "drop",
+	}
+	localACL2 := Acl{
+		Core: localCore2,
+		Log:  false,
+	}
+
+	if err := ovsdbClient.CreateACL(lswitch, localCore2.Direction,
+		localCore2.Priority, localCore2.Match, localCore2.Action); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have two ACL entries to be listed.
+	ovsdbACLs, err = ovsdbClient.ListACLs(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbACLs) != 2 {
+		t.Errorf("expected 2 ACL entry. Got %d instead.", len(ovsdbACLs))
+	}
+
+	checkCorrectness(ovsdbACLs, localACL1, localACL2)
+
+	// Delete the first ACL rule.
+	if err := ovsdbClient.DeleteACL(lswitch, ovsdbACL1); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have only one ACL entry to be listed.
+	ovsdbACLs, err = ovsdbClient.ListACLs(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ovsdbACL2 := ovsdbACLs[0]
+
+	if len(ovsdbACLs) != 1 {
+		t.Errorf("expected 1 ACL entry. Got %d instead.", len(ovsdbACLs))
+	}
+
+	checkCorrectness(ovsdbACLs, localACL2)
+
+	// Delete the other ACL rule.
+	if err := ovsdbClient.DeleteACL(lswitch, ovsdbACL2); err != nil {
+		t.Error(err)
+	}
+
+	// It should now have only one ACL entry to be listed.
+	ovsdbACLs, err = ovsdbClient.ListACLs(lswitch)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ovsdbACLs) != 0 {
+		t.Errorf("expected 0 ACL entry. Got %d instead.", len(ovsdbACLs))
+	}
+
+}
+
+func TestInterfaces(t *testing.T) {
+	ovsdbClient := NewFakeOvsdbClient()
+
+	// Create new switch.
+	lswitch1 := "test-switch-1"
+	if err := ovsdbClient.CreateLogicalSwitch(lswitch1); err != nil {
+		t.Error(err)
+	}
+
+	key := func(val interface{}) interface{} {
+		iface := val.(Interface)
+		return struct {
+			name, bridge string
+		}{
+			name:   iface.Name,
+			bridge: iface.Bridge,
+		}
+	}
+
+	checkCorrectness := func(ovsdbIfaces []Interface, localIfaces ...Interface) {
+		pair, _, _ := join.HashJoin(InterfaceSlice(ovsdbIfaces),
+			InterfaceSlice(localIfaces), key, key)
+		if len(pair) != len(ovsdbIfaces) {
+			t.Errorf("local interfaces do not match ovsdb interfaces.")
+		}
+	}
+
+	// Create a new Bridge. In quilt this is usually done in supervisor.
+	_, err := ovsdbClient.transact("Open_vSwitch", ovs.Operation{
+		Op:    "insert",
+		Table: "Bridge",
+		Row:   map[string]interface{}{"name": lswitch1},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create one interface.
+	iface1 := Interface{
+		Name:   "iface1",
+		Bridge: lswitch1,
+	}
+
+	if err := ovsdbClient.CreateInterface(iface1.Bridge, iface1.Name); err != nil {
+		t.Error(err)
+	}
+
+	ifaces, err := ovsdbClient.ListInterfaces()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ifaces) != 1 {
+		t.Errorf("expected 1 interfaces. Got %d instead.", len(ifaces))
+	}
+
+	checkCorrectness(ifaces, iface1)
+
+	// Now create a new switch and bridge. Attach one new interface to them.
+
+	// Create new switch.
+	lswitch2 := "test-switch-2"
+	if err := ovsdbClient.CreateLogicalSwitch(lswitch2); err != nil {
+		t.Error(err)
+	}
+
+	// Create a new Bridge.
+	_, err = ovsdbClient.transact("Open_vSwitch", ovs.Operation{
+		Op:    "insert",
+		Table: "Bridge",
+		Row:   map[string]interface{}{"name": lswitch2},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Create a new interface.
+	iface2 := Interface{
+		Name:   "iface2",
+		Bridge: lswitch2,
+	}
+
+	if err := ovsdbClient.CreateInterface(iface2.Bridge, iface2.Name); err != nil {
+		t.Error(err)
+	}
+
+	ifaces, err = ovsdbClient.ListInterfaces()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ifaces) != 2 {
+		t.Errorf("expected 2 interfaces. Got %d instead.", len(ifaces))
+	}
+
+	checkCorrectness(ifaces, iface1, iface2)
+
+	iface1, iface2 = ifaces[0], ifaces[1]
+
+	// Delete interface 1.
+	if err := ovsdbClient.DeleteInterface(iface1); err != nil {
+		t.Error(err)
+	}
+
+	ifaces, err = ovsdbClient.ListInterfaces()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ifaces) != 1 {
+		t.Errorf("expected 1 interfaces. Got %d instead.", len(ifaces))
+	}
+
+	checkCorrectness(ifaces, iface2)
+
+	// Delete interface 2.
+	if err := ovsdbClient.DeleteInterface(iface2); err != nil {
+		t.Error(err)
+	}
+
+	ifaces, err = ovsdbClient.ListInterfaces()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(ifaces) != 0 {
+		t.Errorf("expected 0 interfaces. Got %d instead.", len(ifaces))
+	}
+
+	// Test ModifyInterface. We do this by creating an interface with type peer,
+	// attach a mac address to it, and add external_ids.
+	iface := Interface{
+		Name:        "test-modify-iface",
+		Peer:        "lolz",
+		AttachedMAC: "00:00:00:00:00:00",
+		Bridge:      lswitch1,
+		Type:        "patch",
+	}
+
+	if err := ovsdbClient.CreateInterface(iface.Bridge, iface.Name); err != nil {
+		t.Error(err)
+	}
+
+	if err := ovsdbClient.ModifyInterface(iface); err != nil {
+		t.Error(err)
+	}
+
+	ifaces, err = ovsdbClient.ListInterfaces()
+	if err != nil {
+		t.Error(err)
+	}
+
+	ovsdbIface := ifaces[0]
+	if ovsdbIface.Name != iface.Name ||
+		ovsdbIface.Peer != iface.Peer ||
+		ovsdbIface.AttachedMAC != iface.AttachedMAC ||
+		ovsdbIface.Bridge != iface.Bridge ||
+		ovsdbIface.Type != iface.Type {
+		t.Errorf("Modify interface not match. Local: %+v. Remote: %+v.",
+			iface, ovsdbIface)
+	}
+
+}
+
+func TestBridgeMac(t *testing.T) {
+	ovsdbClient := NewFakeOvsdbClient()
+
+	// Create new switch and a new bridge.
+	lswitch := "test-switch"
+	if err := ovsdbClient.CreateLogicalSwitch(lswitch); err != nil {
+		t.Error(err)
+	}
+
+	_, err := ovsdbClient.transact("Open_vSwitch", ovs.Operation{
+		Op:    "insert",
+		Table: "Bridge",
+		Row:   map[string]interface{}{"name": lswitch},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	mac := "00:00:00:00:00:00"
+	if err := ovsdbClient.SetBridgeMac(lswitch, mac); err != nil {
+		t.Error(err)
+	}
+
+	bridgeReply, err := ovsdbClient.transact("Open_vSwitch", ovs.Operation{
+		Op:    "select",
+		Table: "Bridge",
+		Where: noCondition(),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	bridge := bridgeReply[0].Rows[0]
+	otherConfig := bridge["other_config"].([]interface{})[1].(map[string]interface{})
+
+	if otherConfig["hwaddr"] != mac {
+		t.Error("failed to set bridge mac.")
+	}
+}
+
+type AclSlice []Acl
+
+func (acls AclSlice) Get(i int) interface{} {
+	return acls[i]
+}
+
+func (acls AclSlice) Len() int {
+	return len(acls)
+}
+
+type LPortSlice []LPort
+
+func (lports LPortSlice) Get(i int) interface{} {
+	return lports[i]
+}
+
+func (lports LPortSlice) Len() int {
+	return len(lports)
 }


### PR DESCRIPTION
Before this patch, there were many redundant ovsdb functions that
causes large amounts of unnecessary ovsdb transactions. That
becomes the performance bottleneck for quilt when booting a large
cluster. This patch simplifies the ovsdb interface, and reduces
O(N) number of ovsdb transactions in terms of number of VMs to O(1).