### PR TITLE
Invariants

### DIFF
--- a/stitch/eval.go
+++ b/stitch/eval.go
@@ -12,6 +12,7 @@ type evalCtx struct {
 	placements  map[Placement]struct{}
 	machines    *[]*astMachine
 	invariants  *[]invariant
+	annotations map[string]string
 
 	containers  *[]astContainer
 	containerID *int
@@ -44,6 +45,7 @@ func (ctx *evalCtx) deepCopy() *evalCtx {
 		containers:  ctx.containers,
 		placements:  ctx.placements,
 		invariants:  ctx.invariants,
+		annotations: ctx.annotations,
 		containerID: ctx.containerID,
 		parent:      parentCopy,
 	}
@@ -299,6 +301,7 @@ func newEvalCtx(parent *evalCtx) evalCtx {
 		make(map[Placement]struct{}),
 		&[]*astMachine{},
 		&[]invariant{},
+		make(map[string]string),
 		&[]astContainer{},
 		&id}
 }

--- a/stitch/graph.go
+++ b/stitch/graph.go
@@ -148,6 +148,7 @@ func (g *Graph) removeNode(label string) {
 // Find all nodes reachable from the given node.
 func (n Node) dfs() []string {
 	reached := map[string]struct{}{}
+	reached[PublicInternetLabel] = struct{}{}
 
 	var explore func(t Node)
 	explore = func(t Node) {

--- a/stitch/graph.go
+++ b/stitch/graph.go
@@ -8,6 +8,7 @@ import (
 type Node struct {
 	Name        string
 	Label       string
+	Annotation  string
 	Connections map[string]Node
 }
 
@@ -40,11 +41,12 @@ func InitializeGraph(spec Stitch) (Graph, error) {
 	}
 
 	for label, cids := range spec.QueryLabels() {
+		annotation := spec.ctx.annotations[label]
 		for _, cid := range cids {
-			g.addNode(fmt.Sprintf("%d", cid), label)
+			g.addNode(fmt.Sprintf("%d", cid), label, annotation)
 		}
 	}
-	g.addNode(PublicInternetLabel, PublicInternetLabel)
+	g.addNode(PublicInternetLabel, PublicInternetLabel, "")
 
 	for _, conn := range spec.QueryConnections() {
 		err := g.addConnection(conn.From, conn.To)
@@ -123,10 +125,11 @@ func (g Graph) getNodes() []Node {
 	return res
 }
 
-func (g *Graph) addNode(cid string, label string) Node {
+func (g *Graph) addNode(cid string, label string, annotation string) Node {
 	n := Node{
 		Name:        cid,
 		Label:       label,
+		Annotation:  annotation,
 		Connections: map[string]Node{},
 	}
 	g.Nodes[cid] = n

--- a/stitch/graph.go
+++ b/stitch/graph.go
@@ -173,6 +173,36 @@ func (n Node) dfs() []string {
 	return reachable
 }
 
+// Find all nodes reachable from the given node.
+// Do not pass through "ACL"-annotated nodes.
+func (n Node) dfsWithACL() []string {
+	reached := map[string]struct{}{}
+	reached[PublicInternetLabel] = struct{}{}
+
+	var explore func(t Node)
+	explore = func(t Node) {
+		for label, node := range t.Connections {
+			if node.Annotation == "ACL" {
+				reached[label] = struct{}{}
+			}
+
+			_, explored := reached[label]
+			if !explored {
+				reached[label] = struct{}{}
+				explore(node)
+			}
+		}
+	}
+	explore(n)
+
+	var reachable []string
+	for l := range reached {
+		reachable = append(reachable, string(l))
+	}
+
+	return reachable
+}
+
 // Compute all the paths between two Nodes.
 func paths(start Node, end Node) ([][]string, bool) {
 	reach := start.dfs()

--- a/stitch/invariant.go
+++ b/stitch/invariant.go
@@ -9,6 +9,8 @@ type invariantType int
 const (
 	// Reachability (reach): two arguments, <from> <to...>
 	reachInvariant = iota
+	// Neighborship (reach-direct) : two arguments, <from> <to>
+	neighborInvariant
 	// On-pathness (between): three arguments, <from> <to> <between>
 	betweenInvariant
 	// Schedulability (enough): zero arguments
@@ -35,13 +37,15 @@ var formImpls map[invariantType]func(graph Graph, inv invariant) bool
 
 func init() {
 	formKeywords = map[string]invariantType{
-		"reach":   reachInvariant,
-		"between": betweenInvariant,
-		"enough":  schedulabilityInvariant,
+		"reach":       reachInvariant,
+		"reachDirect": neighborInvariant,
+		"between":     betweenInvariant,
+		"enough":      schedulabilityInvariant,
 	}
 
 	formImpls = map[invariantType]func(graph Graph, inv invariant) bool{
 		reachInvariant:          reachImpl,
+		neighborInvariant:       neighborImpl,
 		betweenInvariant:        betweenImpl,
 		schedulabilityInvariant: schedulabilityImpl,
 	}
@@ -73,6 +77,30 @@ func reachImpl(graph Graph, inv invariant) bool {
 	for _, from := range fromNodes {
 		for _, to := range toNodes {
 			pass := contains(from.dfs(), to.Name) == inv.target
+			allPassed = allPassed && pass
+		}
+	}
+
+	return allPassed
+}
+
+func neighborImpl(graph Graph, inv invariant) bool {
+	var fromNodes []Node
+	var toNodes []Node
+	for _, node := range graph.Nodes {
+		if node.Label == inv.nodes[0] {
+			fromNodes = append(fromNodes, node)
+		}
+		if node.Label == inv.nodes[1] {
+			toNodes = append(toNodes, node)
+		}
+	}
+
+	allPassed := true
+	for _, from := range fromNodes {
+		for _, to := range toNodes {
+			_, ok := from.Connections[to.Name]
+			pass := ok == inv.target
 			allPassed = allPassed && pass
 		}
 	}

--- a/stitch/invariant.go
+++ b/stitch/invariant.go
@@ -73,15 +73,16 @@ func reachImpl(graph Graph, inv invariant) bool {
 		}
 	}
 
-	allPassed := true
 	for _, from := range fromNodes {
 		for _, to := range toNodes {
-			pass := contains(from.dfs(), to.Name) == inv.target
-			allPassed = allPassed && pass
+			if pass := contains(from.dfs(),
+				to.Name) == inv.target; !pass {
+				return false
+			}
 		}
 	}
 
-	return allPassed
+	return true
 }
 
 func neighborImpl(graph Graph, inv invariant) bool {
@@ -96,16 +97,16 @@ func neighborImpl(graph Graph, inv invariant) bool {
 		}
 	}
 
-	allPassed := true
 	for _, from := range fromNodes {
 		for _, to := range toNodes {
 			_, ok := from.Connections[to.Name]
-			pass := ok == inv.target
-			allPassed = allPassed && pass
+			if pass := ok == inv.target; !pass {
+				return false
+			}
 		}
 	}
 
-	return allPassed
+	return true
 }
 
 func betweenImpl(graph Graph, inv invariant) bool {

--- a/stitch/invariant.go
+++ b/stitch/invariant.go
@@ -11,6 +11,9 @@ const (
 	reachInvariant = iota
 	// Neighborship (reach-direct) : two arguments, <from> <to>
 	neighborInvariant
+	// Reachability, don't pass through ACL-annotated nodes (reachACL):
+	// two arguments, <from> <to...>
+	reachACLInvariant
 	// On-pathness (between): three arguments, <from> <to> <between>
 	betweenInvariant
 	// Schedulability (enough): zero arguments
@@ -39,6 +42,7 @@ func init() {
 	formKeywords = map[string]invariantType{
 		"reach":       reachInvariant,
 		"reachDirect": neighborInvariant,
+		"reachACL":    reachACLInvariant,
 		"between":     betweenInvariant,
 		"enough":      schedulabilityInvariant,
 	}
@@ -46,6 +50,7 @@ func init() {
 	formImpls = map[invariantType]func(graph Graph, inv invariant) bool{
 		reachInvariant:          reachImpl,
 		neighborInvariant:       neighborImpl,
+		reachACLInvariant:       reachACLImpl,
 		betweenInvariant:        betweenImpl,
 		schedulabilityInvariant: schedulabilityImpl,
 	}
@@ -101,6 +106,30 @@ func neighborImpl(graph Graph, inv invariant) bool {
 		for _, to := range toNodes {
 			_, ok := from.Connections[to.Name]
 			if pass := ok == inv.target; !pass {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func reachACLImpl(graph Graph, inv invariant) bool {
+	var fromNodes []Node
+	var toNodes []Node
+	for _, node := range graph.Nodes {
+		if node.Label == inv.nodes[0] {
+			fromNodes = append(fromNodes, node)
+		}
+		if node.Label == inv.nodes[1] {
+			toNodes = append(toNodes, node)
+		}
+	}
+
+	for _, from := range fromNodes {
+		for _, to := range toNodes {
+			if pass := contains(from.dfsWithACL(),
+				to.Name) == inv.target; !pass {
 				return false
 			}
 		}

--- a/stitch/invariant_test.go
+++ b/stitch/invariant_test.go
@@ -30,6 +30,22 @@ func TestReach(t *testing.T) {
 	}
 }
 
+func TestNeighbor(t *testing.T) {
+	stc := `(label "a" (docker "ubuntu"))
+(label "b" (docker "ubuntu"))
+(label "c" (docker "ubuntu"))
+
+(connect 22 "a" "b")
+(connect 22 "b" "c")
+
+(invariant reachDirect false "a" "c")
+(invariant reachDirect true "b" "c")`
+	_, err := initSpec(stc)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestFail(t *testing.T) {
 	stc := `(label "a" (docker "ubuntu"))
 (label "b" (docker "ubuntu"))

--- a/stitch/invariant_test.go
+++ b/stitch/invariant_test.go
@@ -46,6 +46,23 @@ func TestNeighbor(t *testing.T) {
 	}
 }
 
+func TestAnnotation(t *testing.T) {
+	stc := `(label "a" (docker "ubuntu"))
+(label "b" (docker "ubuntu"))
+(label "c" (docker "ubuntu"))
+
+(connect 22 "a" "b")
+(connect 22 "b" "c")
+
+(annotate ACL "b")
+(invariant reachACL false "a" "c")
+`
+	_, err := initSpec(stc)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestFail(t *testing.T) {
 	stc := `(label "a" (docker "ubuntu"))
 (label "b" (docker "ubuntu"))


### PR DESCRIPTION
This PR is two small features.
1. Don't allow DFS to work through the "public" label (bug fix)
2. Add an invariant type that checks that two labels are directly connected.

For the second feature, it's possible that in the future this invariant and the main reach invariant could be combined in an invariant that takes a depth argument, but (imho) this isn't worth doing right now.