### PR TITLE
azure: Properly return errors when setting up the Azure provider

### DIFF
--- a/cluster/provider/azure.go
+++ b/cluster/provider/azure.go
@@ -67,13 +67,13 @@ func (clst *azureCluster) Connect(namespace string) error {
 
 	cred, err := clst.loadCredentials()
 	if err != nil {
-		return nil
+		return err
 	}
 	clst.subscriptionID = cred.subscriptionID
 
 	spt, err := clst.generateOAuthToken(cred)
 	if err != nil {
-		return nil
+		return err
 	}
 	clst.azureClient = newAzureClient(clst.subscriptionID, spt)
 


### PR DESCRIPTION
We weren't properly returning an error when attempting to load the Azure
credentials. This caused `cluster` to think that the Azure provider was usable,
when it really wasn't.