### PR TITLE
Godep: Fix conflicting grpc on godep restore

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -544,7 +544,8 @@
 		},
 		{
 			"ImportPath": "google.golang.org/grpc/transport",
-			"Rev": "ce6213360cb8fadd0b08f9513406176ec931c5f7"
+			"Comment": "v1.0.0-151-g35896af",
+			"Rev": "35896af9ad39c1fb1b1cd925fe3621be361e3d81"
 		},
 		{
 			"ImportPath": "github.com/dgrijalva/jwt-go",


### PR DESCRIPTION
The grpc upgrade patch successfully compiled, but a created a
Godep conflict that prevented `godep restore` from working
properly.