### PR TITLE
quilt-tester: Change CmdExec test to use `sh`

### DIFF
--- a/quilt-tester/tester_test.go
+++ b/quilt-tester/tester_test.go
@@ -18,7 +18,7 @@ func TestCmdExec(t *testing.T) {
 
 	expStdout := "standard out"
 	expStderr := "standard error"
-	cmd := exec.Command("bash", "-c",
+	cmd := exec.Command("sh", "-c",
 		fmt.Sprintf("echo %s ; echo %s 1>&2", expStdout, expStderr))
 	stdout, stderr, err := execCmd(cmd, "PREFIX")
 


### PR DESCRIPTION
The Dockerhub build was failing because `bash` wasn't in the path.

My guess is that this will fix the Dockerhub build. Not 100% sure though.