### PR TITLE
quilt-tester: Gather command output before `Wait`ing

### DIFF
--- a/quilt-tester/exec.go
+++ b/quilt-tester/exec.go
@@ -152,9 +152,11 @@ func execCmd(cmd *exec.Cmd, logLineTitle string) (string, string, error) {
 		return "", "", err
 	}
 
+	stdout := <-stdoutChan
+	stderr := <-stderrChan
 	err = cmd.Wait()
 	l.infoln(fmt.Sprintf("%s: Completed command: %v", logLineTitle, cmd.Args))
-	return <-stdoutChan, <-stderrChan, err
+	return stdout, stderr, err
 }
 
 func sshGen(host string, cmd *exec.Cmd) *exec.Cmd {


### PR DESCRIPTION
We were seeing intermittent test failures where not all of the stdout
and stderr output was gathered before returning. This was because
"wait will close the pipe after seeing the command exit". Thus, `Wait()`
would sometimes close the output pipes before the functions grabbing the
output had a chance to read the entire buffer.