### PR TITLE
quilt-tester: Allow building on Dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,9 @@ docker-build-dev:
 	cd -P . && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build . \
 	    && ${DOCKER} build -t ${REPO}/quilt -f Dockerfile.Dev .
 
-docker-build-tester: tests
+docker-build-tester-dev: tests
 	cd -P quilt-tester && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/quilt-tester . \
-	&& ${DOCKER} build -t ${REPO}/tester .
+	&& ${DOCKER} build -t ${REPO}/tester -f Dockerfile.Dev .
 
 docker-build-ovs:
 	cd -P ovs && docker build -t ${REPO}/ovs .

--- a/quilt-tester/Dockerfile
+++ b/quilt-tester/Dockerfile
@@ -1,9 +1,30 @@
 From quilt/quilt
 Maintainer Ethan J. Jackson
 
-RUN apk add --no-cache bash git python curl openssh-client
-Copy bin/* /bin/
-Copy tests /tests
+RUN VER=1.6.2 \
+&& export GOROOT=/tmp/build/go GOPATH=/tmp/build/gowork \
+&& export PATH=$PATH:$GOROOT/bin \
+&& apk update \
+&& apk add --no-cache bash git python curl openssh-client \
+# Alpine uses musl instead of glibc which confuses go.
+# They're compatible, so just symlink
+&& mkdir /tmp/build && cd /tmp/build \
+&& wget https://storage.googleapis.com/golang/go$VER.linux-amd64.tar.gz \
+&& gunzip -c go$VER.linux-amd64.tar.gz | tar x \
+&& go get -u github.com/NetSys/quilt \
+&& cd $GOPATH/src/github.com/NetSys/quilt/quilt-tester \
+&& go build -o /bin/quilt-tester . \
+&& mkdir /tests \
+&& for suite in tests/* ; do \
+	for f in $suite/* ; do \
+		extension=$(echo "$f" | awk -F'.' '{print $NF}') ; \
+		if [ $extension == "go" ] ; then \
+			go build -v -o ${f%???} $f ; \
+		fi; \
+	done; \
+	cp -r $suite /tests ; \
+done \
+&& rm -rf /tmp/build
 Copy config/id_rsa /root/.ssh/id_rsa
 RUN chmod 0600 /root/.ssh/id_rsa
 

--- a/quilt-tester/Dockerfile.Dev
+++ b/quilt-tester/Dockerfile.Dev
@@ -1,0 +1,10 @@
+From quilt/quilt
+Maintainer Ethan J. Jackson
+
+RUN apk add --no-cache bash git python curl openssh-client
+Copy bin/* /bin/
+Copy tests /tests
+Copy config/id_rsa /root/.ssh/id_rsa
+RUN chmod 0600 /root/.ssh/id_rsa
+
+Entrypoint ["quilt-tester"]


### PR DESCRIPTION
Before, the `quilt-tester` and test suite binaries were compiled outside
the Dockerfile environment, and then COPYed in. This wasn't compatible
with the way Dockerhub builds images. This patch makes the
`quilt-tester` Dockerfile self-dependent, and moves the old Dockerfile
to Dockerfile.dev as a convenience for `quilt-tester` developers.