### PR TITLE
ovsdb: Fix broken network

### DIFF
--- a/minion/ovsdb/ovsdb.go
+++ b/minion/ovsdb/ovsdb.go
@@ -601,9 +601,10 @@ func ifaceFromRow(row row) (Interface, error) {
 		return iface, err
 	}
 
-	ofport, ok := row["ofport"].(int)
+	ofport, ok := row["ofport"].(float64)
 	if ok {
-		iface.OFPort = &ofport
+		port := int(ofport)
+		iface.OFPort = &port
 	}
 
 	// The following map keys could be missing without breaking the Schema in the

--- a/minion/ovsdb/ovsdb_mock.go
+++ b/minion/ovsdb/ovsdb_mock.go
@@ -18,7 +18,7 @@ func NewFakeOvsdbClient() Client {
 }
 
 // Default OFPort used during creation of interface.
-const defaultOFPort = 123
+const defaultOFPort float64 = 123
 
 type fakeOvsdbClient struct {
 	databases map[string]fakeDb

--- a/minion/ovsdb/ovsdb_test.go
+++ b/minion/ovsdb/ovsdb_test.go
@@ -287,9 +287,11 @@ func TestInterfaces(t *testing.T) {
 		iface := val.(Interface)
 		return struct {
 			name, bridge string
+			ofport       int
 		}{
 			name:   iface.Name,
 			bridge: iface.Bridge,
+			ofport: *iface.OFPort,
 		}
 	}
 
@@ -311,10 +313,14 @@ func TestInterfaces(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Ovsdb mock uses defaultOFPort as the ofport created for each interface.
+	expectedOFPort := int(defaultOFPort)
+
 	// Create one interface.
 	iface1 := Interface{
 		Name:   "iface1",
 		Bridge: lswitch1,
+		OFPort: &expectedOFPort,
 	}
 
 	if err := ovsdbClient.CreateInterface(iface1.Bridge, iface1.Name); err != nil {
@@ -354,6 +360,7 @@ func TestInterfaces(t *testing.T) {
 	iface2 := Interface{
 		Name:   "iface2",
 		Bridge: lswitch2,
+		OFPort: &expectedOFPort,
 	}
 
 	if err := ovsdbClient.CreateInterface(iface2.Bridge, iface2.Name); err != nil {


### PR DESCRIPTION
Before this patch, ofport was never correctly listed and no flows were
correctly installed. This patch fixes this by parsing the ofport type
correctly.