### PR TITLE
tester: Provide build information in logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ RUN VER=1.6.2 \
 && go test github.com/NetSys/quilt/... \
 && go install github.com/NetSys/quilt \
 && cp $GOPATH/bin/* /\
+&& git -C "$GOPATH/src/github.com/NetSys/quilt/" show --pretty=medium --no-patch \
+	> /buildinfo \
 && rm -rf /tmp/build \
 && apk del .build_deps

--- a/quilt-tester/io.go
+++ b/quilt-tester/io.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"time"
@@ -50,6 +51,7 @@ func newLogger(myIP string) (logger, error) {
 	passedDir := filepath.Join(webDir, "passed")
 	failedDir := filepath.Join(webDir, "failed")
 	logDir := filepath.Join(webDir, "log")
+	buildinfoPath := filepath.Join(webDir, "buildinfo")
 
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		return logger{}, err
@@ -59,6 +61,9 @@ func newLogger(myIP string) (logger, error) {
 	}
 	if err := os.MkdirAll(failedDir, 0755); err != nil {
 		return logger{}, err
+	}
+	if err := exec.Command("cp", "/buildinfo", buildinfoPath).Run(); err != nil {
+		logrus.WithError(err).Error("Failed to copy build info.")
 	}
 
 	latestSymlink := filepath.Join(webRoot, "latest")


### PR DESCRIPTION
After this patch, quilt-tester includes in each testing directory
a file called buildinfo. buildinfo contains the commit summary of
the latest commit when the quilt/quilt image was built, and the
GitHub URL for that commit.