### PR TITLE
stitch: Get github sshkeys with get request instead of github api

### DIFF
--- a/stitch/key_test.go
+++ b/stitch/key_test.go
@@ -1,0 +1,32 @@
+package stitch
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGetGithubKeys(t *testing.T) {
+	expected := []string{"key1", "key2", "key3"}
+	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, strings.Join(expected, "\n"))
+	})
+	ts := httptest.NewServer(handlerFunc)
+	defer ts.Close()
+
+	actual, err := getGithubKeys(ts.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("expected %s \n but got %s", expected, actual)
+	}
+
+	actual, err = getGithubKeys("Not a URL")
+	if actual != nil || err == nil {
+		t.Errorf("expected error did not occur")
+	}
+}

--- a/stitch/stitch_test.go
+++ b/stitch/stitch_test.go
@@ -1,7 +1,10 @@
 package stitch
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"reflect"
 	"regexp"
 	"strings"
@@ -686,8 +689,11 @@ func TestMachineAttribute(t *testing.T) {
 }
 
 func TestKeys(t *testing.T) {
-	getGithubKeys = func(username string) ([]string, error) {
-		return []string{username}, nil
+	httpGet = func(url string) (*http.Response, error) {
+		resp := http.Response{
+			Body: ioutil.NopCloser(bytes.NewBufferString("githubkeys")),
+		}
+		return &resp, nil
 	}
 
 	checkKeys := func(code, expectedCode string, expected ...string) {
@@ -707,10 +713,10 @@ func TestKeys(t *testing.T) {
 	checkKeys(code, code, "key")
 
 	code = `(machine (githubKey "user"))`
-	checkKeys(code, code, "user")
+	checkKeys(code, code, "githubkeys")
 
 	code = `(machine (githubKey "user") (sshkey "key"))`
-	checkKeys(code, code, "user", "key")
+	checkKeys(code, code, "githubkeys", "key")
 }
 
 func TestLabel(t *testing.T) {


### PR DESCRIPTION
This patch should solve the github api key rate error problem as you can curl their site for the keys seemingly without limit.