### PR TITLE
quiltctl: Remind user to start daemon before running spec

### DIFF
--- a/quiltctl/command/error.go
+++ b/quiltctl/command/error.go
@@ -11,6 +11,7 @@ type DaemonConnectError struct {
 }
 
 func (err DaemonConnectError) Error() string {
-	return fmt.Sprintf("Unable to connect to the Quilt daemon at %s: %s.",
-		err.host, err.connectError.Error())
+	return fmt.Sprintf("Unable to connect to the Quilt daemon at %s: %s. "+
+		"Is the quilt daemon running? If not, you can start it with "+
+		"`quilt daemon`.", err.host, err.connectError.Error())
 }


### PR DESCRIPTION
Before, when a user tried to run a spec before starting the daemon,
they would only get an error message reporting that they were unable
to connect to the daemon. Now, they will also receive a reminder to
start the daemon before attempting to run a spec.