### PR TITLE
minion: Remove docker swarm from the cluster

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -119,7 +119,6 @@ You can run `docker ps` to list the containers running on your Worker VM.
 quilt@ip-172-31-1-198:~$ docker ps
 CONTAINER ID        IMAGE                        COMMAND                  CREATED             STATUS              PORTS               NAMES
 4ec5926bfbab        quilt/ovs                    "run ovn-northd"         2 hours ago         Up 2 hours                              ovn-northd
-70b785769fc8        swarm:1.2.3                  "/swarm manage --repl"   2 hours ago         Up 2 hours                              swarm
 855e6ff38345        quilt/ovs                    "run ovsdb-server"       2 hours ago         Up 2 hours                              ovsdb-server
 fb0f44812f30        quay.io/coreos/etcd:v2.3.6   "/etcd --name=master-"   2 hours ago         Up 2 hours                              etcd
 79ca96065912        quilt/quilt:latest           "/minion"                2 hours ago         Up 2 hours                              minion

--- a/minion/supervisor/supervisor_test.go
+++ b/minion/supervisor/supervisor_test.go
@@ -64,7 +64,6 @@ func TestMaster(t *testing.T) {
 	exp := map[string][]string{
 		Etcd:  etcdArgsMaster(ip, etcdIPs),
 		Ovsdb: {"ovsdb-server"},
-		Swarm: swarmArgsMaster(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -95,7 +94,6 @@ func TestMaster(t *testing.T) {
 	exp = map[string][]string{
 		Etcd:      etcdArgsMaster(ip, etcdIPs),
 		Ovsdb:     {"ovsdb-server"},
-		Swarm:     swarmArgsMaster(ip),
 		Ovnnorthd: {"ovn-northd"},
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
@@ -119,7 +117,6 @@ func TestMaster(t *testing.T) {
 	exp = map[string][]string{
 		Etcd:  etcdArgsMaster(ip, etcdIPs),
 		Ovsdb: {"ovsdb-server"},
-		Swarm: swarmArgsMaster(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -180,7 +177,6 @@ func TestWorker(t *testing.T) {
 		Ovsdb:         {"ovsdb-server"},
 		Ovncontroller: {"ovn-controller"},
 		Ovsvswitchd:   {"ovs-vswitchd"},
-		Swarm:         swarmArgsWorker(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -219,7 +215,6 @@ func TestChange(t *testing.T) {
 		Ovsdb:         {"ovsdb-server"},
 		Ovncontroller: {"ovn-controller"},
 		Ovsvswitchd:   {"ovs-vswitchd"},
-		Swarm:         swarmArgsWorker(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -246,7 +241,6 @@ func TestChange(t *testing.T) {
 	exp = map[string][]string{
 		Etcd:  etcdArgsMaster(ip, etcdIPs),
 		Ovsdb: {"ovsdb-server"},
-		Swarm: swarmArgsMaster(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -270,7 +264,6 @@ func TestChange(t *testing.T) {
 		Ovsdb:         {"ovsdb-server"},
 		Ovncontroller: {"ovn-controller"},
 		Ovsvswitchd:   {"ovs-vswitchd"},
-		Swarm:         swarmArgsWorker(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -305,7 +298,6 @@ func TestEtcdAdd(t *testing.T) {
 	exp := map[string][]string{
 		Etcd:  etcdArgsMaster(ip, etcdIPs),
 		Ovsdb: {"ovsdb-server"},
-		Swarm: swarmArgsMaster(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -328,7 +320,6 @@ func TestEtcdAdd(t *testing.T) {
 	exp = map[string][]string{
 		Etcd:  etcdArgsMaster(ip, etcdIPs),
 		Ovsdb: {"ovsdb-server"},
-		Swarm: swarmArgsMaster(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -355,7 +346,6 @@ func TestEtcdRemove(t *testing.T) {
 	exp := map[string][]string{
 		Etcd:  etcdArgsMaster(ip, etcdIPs),
 		Ovsdb: {"ovsdb-server"},
-		Swarm: swarmArgsMaster(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -378,7 +368,6 @@ func TestEtcdRemove(t *testing.T) {
 	exp = map[string][]string{
 		Etcd:  etcdArgsMaster(ip, etcdIPs),
 		Ovsdb: {"ovsdb-server"},
-		Swarm: swarmArgsMaster(ip),
 	}
 	if !reflect.DeepEqual(ctx.fd.running(), exp) {
 		t.Errorf("fd.running = %s\n\nwant %s", spew.Sdump(ctx.fd.running()),
@@ -449,17 +438,6 @@ func (f fakeDocker) running() map[string][]string {
 	return res
 }
 
-func swarmArgsMaster(ip string) []string {
-	addr := ip + ":2377"
-	return []string{"manage", "--replication", "--addr=" + addr,
-		"--host=" + addr, "etcd://127.0.0.1:2379"}
-}
-
-func swarmArgsWorker(ip string) []string {
-	addr := fmt.Sprintf("--addr=%s:2375", ip)
-	return []string{"join", addr, "etcd://127.0.0.1:2379"}
-}
-
 func etcdArgsMaster(ip string, etcdIPs []string) []string {
 	return []string{
 		fmt.Sprintf("--name=master-%s", ip),
@@ -498,7 +476,6 @@ func ovsExecArgs(ip, leader string) []string {
 func validateImage(image string) {
 	switch image {
 	case Etcd:
-	case Swarm:
 	case Ovnnorthd:
 	case Ovncontroller:
 	case Ovsvswitchd:

--- a/specs/spark/README.md
+++ b/specs/spark/README.md
@@ -97,4 +97,4 @@ Pi is roughly 3.13918
 
 **Note:** The Spark cluster is now up and usable. You can run the interactive
 spark-shell by exec-ing it in the Master Spark container:
-`swarm exec -it <MASTER_CONTAINER_NAME> spark-shell`
+`quilt exec -it <MASTER_CONTAINER_ID> spark-shell`


### PR DESCRIPTION
This patch completely removes docker swarm from the cluster.  Swarm
became obsolete in quilt when the custom scheduler was merged.
Furthermore, it presented somewhat of a security risk as it allowed
remote access to docker containers.