### PR TITLE
travis: Build the production Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: go
 
+sudo: required
+
+services:
+      - docker
+
 go:
 - 1.7
 - 1.6

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ tests:
 		done \
 	done
 
+docker-build-prod:
+	${DOCKER} build -t ${REPO}/quilt .
+
 docker-build-dev:
 	cd -P . && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build . \
 	    && ${DOCKER} build -t ${REPO}/quilt -f Dockerfile.Dev .

--- a/scripts/build-push.sh
+++ b/scripts/build-push.sh
@@ -9,4 +9,4 @@ set -e
 
 status_line "Begin build..."
 
-make all check lint format-check coverage
+make all check lint format-check coverage docker-build-prod


### PR DESCRIPTION
By building the production Dockerfile as part of CI, we'll catch
errors before they get into the docker build system.  This would have
caught a rather annoying error much earlier in the development
process.