### PR TITLE
spark: Fix incorrect instruction in README.md

### DIFF
--- a/specs/spark/README.md
+++ b/specs/spark/README.md
@@ -97,4 +97,4 @@ Pi is roughly 3.13918
 
 **Note:** The Spark cluster is now up and usable. You can run the interactive
 spark-shell by exec-ing it in the Master Spark container:
-`quilt exec -it <MASTER_CONTAINER_ID> spark-shell`
+`quilt exec <MASTER_CONTAINER_ID> spark-shell`


### PR DESCRIPTION
The Spark README.md suggested that we run `quilt exec -it` when `quilt
exec` alone is correct.