### PR TITLE
docker: Stop using docker exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
-From alpine:3.3
+From quilt/ovs
 Maintainer Ethan J. Jackson
+
+ENV build_deps \
+    build-essential \
+    git \
+    wget
 
 RUN VER=1.7 \
 && export GOROOT=/tmp/build/go GOPATH=/tmp/build/gowork \
 && export PATH=$PATH:$GOROOT/bin \
-&& apk update \
-&& apk add --no-cache ca-certificates git --virtual .build_deps \
-&& apk add --no-cache iproute2 \
 && mkdir -p /var/run/netns \
-# Alpine uses musl instead of glibc which confuses go.
-# They're compatible, so just symlink
-&& mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
 && mkdir /tmp/build && cd /tmp/build \
+&& apt-get update \
+&& apt-get install -y ${build_deps} \
+&& apt-get install -y --no-install-recommends iproute2 iptables \
 && wget https://storage.googleapis.com/golang/go$VER.linux-amd64.tar.gz \
 && gunzip -c go$VER.linux-amd64.tar.gz | tar x \
 && go get -u github.com/NetSys/quilt \
 && go test github.com/NetSys/quilt/... \
 && go install github.com/NetSys/quilt \
-&& cp $GOPATH/bin/* /usr/local/bin\
-&& git -C "$GOPATH/src/github.com/NetSys/quilt/" show --pretty=medium --no-patch \
-	> /buildinfo \
+&& cp $GOPATH/bin/* /usr/local/bin \
+&& git -C "$GOPATH/src/github.com/NetSys/quilt/" show --pretty=medium \
+    --no-patch > /buildinfo \
 && rm -rf /tmp/build \
-&& apk del .build_deps
+&& apt-get remove --purge -y ${build_deps} \
+&& apt-get autoremove -y --purge \
+&& rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.Dev
+++ b/Dockerfile.Dev
@@ -1,5 +1,10 @@
-From alpine:3.3
+From quilt/ovs
 Maintainer Ethan J. Jackson
 
-RUN apk add --no-cache iproute2 && mkdir -p /var/run/netns
+RUN mkdir -p /var/run/netns \
+&& apt-get update \
+&& apt-get install -y --no-install-recommends iproute2 iptables \
+&& rm -rf /var/lib/apt/lists/*
+
 Copy ./quilt /usr/local/bin/quilt
+ENTRYPOINT []

--- a/minion/docker/docker_test.go
+++ b/minion/docker/docker_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	dkc "github.com/fsouza/go-dockerclient"
 )
 
 func TestPull(t *testing.T) {
@@ -316,60 +315,6 @@ func TestRemove(t *testing.T) {
 
 	if len(containers) > 0 {
 		t.Errorf(spew.Sprintf("Unexpected containers: %v", containers))
-	}
-}
-
-func TestExec(t *testing.T) {
-	t.Parallel()
-	md, dk := NewMock()
-
-	_, err := md.CreateExec(dkc.CreateExecOptions{Container: "Missing"})
-	if err == nil {
-		t.Error("Expected Error")
-	}
-
-	_, err = dk.Run(RunOptions{Name: "name"})
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-
-	cmd := []string{"cmd", "arg"}
-
-	err = dk.Exec("missing", cmd...)
-	if err == nil {
-		t.Error("Expected Error")
-	}
-
-	md.CreateExecError = true
-	err = dk.Exec("name", cmd...)
-	if err == nil {
-		t.Error("Expected Error")
-	}
-	md.CreateExecError = false
-
-	md.StartExecError = true
-	err = dk.Exec("name", cmd...)
-	if err == nil {
-		t.Error("Expected Error")
-	}
-	md.StartExecError = false
-
-	err = dk.Exec("name", cmd...)
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-
-	err = dk.Exec("name", append(cmd, "arg2")...)
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-
-	md.ResetExec()
-	if len(md.Executions) > 0 {
-		t.Errorf("Bad Executions %v", md.Executions)
-	}
-	if len(md.createdExecs) > 0 {
-		t.Errorf("Bad Executions %v", md.createdExecs)
 	}
 }
 


### PR DESCRIPTION
We're currently dealing with a docker bug in which the docker daemon
deadlocks occasionally.  While looking through stack traces we've
noticed that the docker daemon appears to be processing exec calls.
Additionally, a month or two ago we noticed that the minion was making
an exec call at the time of the deadlock.  This patch deals with the
issue by removing all exec calls from the minion.

A happy side effect of the approach this patch takes, is slightly
cleaner code.  All of the exec calls before this patch were to access
OVS utilities that are now bundled with the minion container directly.