### PR TITLE
Table locks

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -42,7 +42,8 @@ var sleep = time.Sleep
 // needed.
 func Run(conn db.Conn) {
 	var clst *cluster
-	for range conn.TriggerTick(30, db.ClusterTable, db.MachineTable, db.ACLTable).C {
+	clusterConn := conn.Restrict(db.ClusterTable, db.MachineTable, db.ACLTable)
+	for range clusterConn.TriggerTick(30).C {
 		clst = updateCluster(conn, clst)
 
 		// Somewhat of a crude rate-limit of once every five seconds to avoid

--- a/db/acl.go
+++ b/db/acl.go
@@ -37,8 +37,9 @@ func (db Database) InsertACL() ACL {
 
 // SelectFromACL gets all acls in the database that satisfy 'check'.
 func (db Database) SelectFromACL(check func(ACL) bool) []ACL {
+	aclTable := db.accessTable(ACLTable)
 	result := []ACL{}
-	for _, row := range db.tables[ACLTable].rows {
+	for _, row := range aclTable.rows {
 		if check == nil || check(row.(ACL)) {
 			result = append(result, row.(ACL))
 		}

--- a/db/cluster.go
+++ b/db/cluster.go
@@ -22,8 +22,9 @@ func (db Database) InsertCluster() Cluster {
 
 // SelectFromCluster gets all clusters in the database that satisfy 'check'.
 func (db Database) SelectFromCluster(check func(Cluster) bool) []Cluster {
+	clusterTable := db.accessTable(ClusterTable)
 	result := []Cluster{}
-	for _, row := range db.tables[ClusterTable].rows {
+	for _, row := range clusterTable.rows {
 		if check == nil || check(row.(Cluster)) {
 			result = append(result, row.(Cluster))
 		}

--- a/db/connection.go
+++ b/db/connection.go
@@ -24,8 +24,9 @@ func (db Database) InsertConnection() Connection {
 
 // SelectFromConnection gets all connections in the database that satisfy 'check'.
 func (db Database) SelectFromConnection(check func(Connection) bool) []Connection {
+	connTable := db.accessTable(ConnectionTable)
 	var result []Connection
-	for _, row := range db.tables[ConnectionTable].rows {
+	for _, row := range connTable.rows {
 		if check == nil || check(row.(Connection)) {
 			result = append(result, row.(Connection))
 		}

--- a/db/container.go
+++ b/db/container.go
@@ -39,8 +39,9 @@ func (db Database) InsertContainer() Container {
 
 // SelectFromContainer gets all containers in the database that satisfy 'check'.
 func (db Database) SelectFromContainer(check func(Container) bool) []Container {
+	containerTable := db.accessTable(ContainerTable)
 	var result []Container
-	for _, row := range db.tables[ContainerTable].rows {
+	for _, row := range containerTable.rows {
 		if check == nil || check(row.(Container)) {
 			result = append(result, row.(Container))
 		}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -391,11 +391,13 @@ func pickTwoTables(taken map[TableType]struct{}) []TableType {
 
 func TestTrigger(t *testing.T) {
 	conn := New()
+	machineConn := conn.Restrict(MachineTable)
+	clusterConn := conn.Restrict(ClusterTable)
 
-	mt := conn.Trigger(MachineTable)
-	mt2 := conn.Trigger(MachineTable)
-	ct := conn.Trigger(ClusterTable)
-	ct2 := conn.Trigger(ClusterTable)
+	mt := machineConn.Trigger()
+	mt2 := machineConn.Trigger()
+	ct := clusterConn.Trigger()
+	ct2 := clusterConn.Trigger()
 
 	triggerNoRecv(t, mt)
 	triggerNoRecv(t, mt2)
@@ -432,7 +434,7 @@ func TestTrigger(t *testing.T) {
 	ct.Stop()
 	ct2.Stop()
 
-	fast := conn.TriggerTick(1, MachineTable)
+	fast := machineConn.TriggerTick(1)
 	triggerRecv(t, fast)
 	triggerRecv(t, fast)
 	triggerRecv(t, fast)
@@ -441,7 +443,7 @@ func TestTrigger(t *testing.T) {
 func TestTriggerTickStop(t *testing.T) {
 	conn := New()
 
-	mt := conn.TriggerTick(100, MachineTable)
+	mt := conn.Restrict(MachineTable).TriggerTick(100)
 
 	// The initial tick.
 	triggerRecv(t, mt)

--- a/db/etcd.go
+++ b/db/etcd.go
@@ -38,8 +38,9 @@ func (db Database) EtcdLeader() bool {
 
 // SelectFromEtcd gets all Etcd rows in the database that satisfy the 'check'.
 func (db Database) SelectFromEtcd(check func(Etcd) bool) []Etcd {
+	etcdTable := db.accessTable(EtcdTable)
 	result := []Etcd{}
-	for _, row := range db.tables[EtcdTable].rows {
+	for _, row := range etcdTable.rows {
 		if check == nil || check(row.(Etcd)) {
 			result = append(result, row.(Etcd))
 		}

--- a/db/label.go
+++ b/db/label.go
@@ -22,8 +22,9 @@ func (db Database) InsertLabel() Label {
 
 // SelectFromLabel gets all labels in the database that satisfy 'check'.
 func (db Database) SelectFromLabel(check func(Label) bool) []Label {
+	labelTable := db.accessTable(LabelTable)
 	var result []Label
-	for _, row := range db.tables[LabelTable].rows {
+	for _, row := range labelTable.rows {
 		if check == nil || check(row.(Label)) {
 			result = append(result, row.(Label))
 		}

--- a/db/logger.go
+++ b/db/logger.go
@@ -11,7 +11,7 @@ func (conn Conn) runLogger() {
 	for _, t := range allTables {
 		t := t
 		go func() {
-			for range conn.Restrict(t).Trigger().C {
+			for range conn.restrict(t).Trigger().C {
 				conn.logTable(t)
 			}
 		}()

--- a/db/logger.go
+++ b/db/logger.go
@@ -11,7 +11,7 @@ func (conn Conn) runLogger() {
 	for _, t := range allTables {
 		t := t
 		go func() {
-			for range conn.Restrict(t).Trigger(t).C {
+			for range conn.Restrict(t).Trigger().C {
 				conn.logTable(t)
 			}
 		}()

--- a/db/logger.go
+++ b/db/logger.go
@@ -11,7 +11,7 @@ func (conn Conn) runLogger() {
 	for _, t := range allTables {
 		t := t
 		go func() {
-			for range conn.Trigger(t).C {
+			for range conn.Restrict(t).Trigger(t).C {
 				conn.logTable(t)
 			}
 		}()

--- a/db/machine.go
+++ b/db/machine.go
@@ -37,8 +37,9 @@ func (db Database) InsertMachine() Machine {
 
 // SelectFromMachine gets all machines in the database that satisfy the 'check'.
 func (db Database) SelectFromMachine(check func(Machine) bool) []Machine {
+	machineTable := db.accessTable(MachineTable)
 	result := []Machine{}
-	for _, row := range db.tables[MachineTable].rows {
+	for _, row := range machineTable.rows {
 		if check == nil || check(row.(Machine)) {
 			result = append(result, row.(Machine))
 		}

--- a/db/minion.go
+++ b/db/minion.go
@@ -30,8 +30,9 @@ func (db Database) InsertMinion() Minion {
 
 // SelectFromMinion gets all minions in the database that satisfy the 'check'.
 func (db Database) SelectFromMinion(check func(Minion) bool) []Minion {
+	minionTable := db.accessTable(MinionTable)
 	result := []Minion{}
-	for _, row := range db.tables[MinionTable].rows {
+	for _, row := range minionTable.rows {
 		if check == nil || check(row.(Minion)) {
 			result = append(result, row.(Minion))
 		}

--- a/db/placement.go
+++ b/db/placement.go
@@ -31,8 +31,9 @@ func (db Database) InsertPlacement() Placement {
 
 // SelectFromPlacement gets all placements in the database that satisfy 'check'.
 func (db Database) SelectFromPlacement(check func(Placement) bool) []Placement {
+	placementTable := db.accessTable(PlacementTable)
 	var result []Placement
-	for _, row := range db.tables[PlacementTable].rows {
+	for _, row := range placementTable.rows {
 		if check == nil || check(row.(Placement)) {
 			result = append(result, row.(Placement))
 		}

--- a/db/table.go
+++ b/db/table.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"reflect"
+	"sync"
 )
 
 // TableType represents a table in the database.
@@ -42,6 +43,7 @@ type table struct {
 
 	triggers    map[Trigger]struct{}
 	shouldAlert bool
+	sync.Mutex
 }
 
 func newTable() *table {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -14,10 +14,9 @@ var myIP = util.MyIP
 var defaultDiskSize = 32
 
 // Run updates the database in response to stitch changes in the cluster table.
-func Run(conn db.Conn) {
-	for range conn.Restrict(db.ClusterTable, db.MachineTable,
-		db.ACLTable).TriggerTick(30).C {
-
+func Run() {
+	conn := db.Open(db.ClusterTable, db.MachineTable, db.ACLTable)
+	for range conn.TriggerTick(30).C {
 		conn.Transact(updateTxn)
 	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -15,7 +15,9 @@ var defaultDiskSize = 32
 
 // Run updates the database in response to stitch changes in the cluster table.
 func Run(conn db.Conn) {
-	for range conn.TriggerTick(30, db.ClusterTable, db.MachineTable, db.ACLTable).C {
+	for range conn.Restrict(db.ClusterTable, db.MachineTable,
+		db.ACLTable).TriggerTick(30).C {
+
 		conn.Transact(updateTxn)
 	}
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -16,7 +16,8 @@ func TestEngine(t *testing.T) {
 		adminACL: ["1.2.3.4/32"],
 	});
 	var baseMachine = new Machine({provider: "Amazon", size: "m4.large"});`
-	conn := db.New()
+	db.Reset()
+	conn := db.Open()
 
 	code := pre + `deployment.deploy(baseMachine.asMaster().replicate(2));
 		deployment.deploy(baseMachine.asWorker().replicate(3));`
@@ -142,7 +143,8 @@ func TestEngine(t *testing.T) {
 
 func TestSort(t *testing.T) {
 	pre := `var baseMachine = new Machine({provider: "Amazon", size: "m4.large"});`
-	conn := db.New()
+	db.Reset()
+	conn := db.Open()
 
 	updateStitch(t, conn, prog(t, pre+`
 	deployment.deploy(baseMachine.asMaster().replicate(3));
@@ -198,7 +200,8 @@ func TestSort(t *testing.T) {
 }
 
 func TestACLs(t *testing.T) {
-	conn := db.New()
+	db.Reset()
+	conn := db.Open()
 
 	code := `createDeployment({adminACL: ["1.2.3.4/32", "local"]})
 		.deploy([

--- a/minion/engine_test.go
+++ b/minion/engine_test.go
@@ -15,7 +15,7 @@ const testImage = "alpine"
 
 func TestContainerTxn(t *testing.T) {
 	conn := db.New()
-	trigg := conn.Trigger(db.ContainerTable).C
+	trigg := conn.Restrict(db.ContainerTable).Trigger().C
 
 	spec := ""
 	testContainerTxn(t, conn, spec)
@@ -116,7 +116,7 @@ func testContainerTxn(t *testing.T, conn db.Conn, spec string) {
 
 func TestConnectionTxn(t *testing.T) {
 	conn := db.New()
-	trigg := conn.Trigger(db.ConnectionTable).C
+	trigg := conn.Restrict(db.ConnectionTable).Trigger().C
 
 	pre := `var a = new Service("a", [new Container("alpine")]);
 	var b = new Service("b", [new Container("alpine")]);

--- a/minion/engine_test.go
+++ b/minion/engine_test.go
@@ -15,7 +15,7 @@ const testImage = "alpine"
 
 func TestContainerTxn(t *testing.T) {
 	conn := db.New()
-	trigg := conn.Restrict(db.ContainerTable).Trigger().C
+	trigg := conn.Trigger().C
 
 	spec := ""
 	testContainerTxn(t, conn, spec)
@@ -116,7 +116,7 @@ func testContainerTxn(t *testing.T, conn db.Conn, spec string) {
 
 func TestConnectionTxn(t *testing.T) {
 	conn := db.New()
-	trigg := conn.Restrict(db.ConnectionTable).Trigger().C
+	trigg := conn.Trigger().C
 
 	pre := `var a = new Service("a", [new Container("alpine")]);
 	var b = new Service("b", [new Container("alpine")]);

--- a/minion/etcd/elector.go
+++ b/minion/etcd/elector.go
@@ -25,8 +25,9 @@ func watchLeader(conn db.Conn, store Store) {
 		tickRate = 30
 	}
 
+	conn = conn.Restrict(db.EtcdTable)
 	watch := store.Watch(leaderKey, 1*time.Second)
-	trigg := conn.TriggerTick(tickRate, db.EtcdTable)
+	trigg := conn.TriggerTick(tickRate)
 	for {
 		leader, _ := store.Get(leaderKey)
 		conn.Transact(func(view db.Database) error {
@@ -46,8 +47,9 @@ func watchLeader(conn db.Conn, store Store) {
 }
 
 func campaign(conn db.Conn, store Store) {
+	conn = conn.Restrict(db.EtcdTable, db.MinionTable)
 	watch := store.Watch(leaderKey, 1*time.Second)
-	trigg := conn.TriggerTick(electionTTL/2, db.EtcdTable)
+	trigg := conn.Restrict(db.EtcdTable).TriggerTick(electionTTL / 2)
 
 	for {
 		select {

--- a/minion/etcd/minion.go
+++ b/minion/etcd/minion.go
@@ -32,9 +32,10 @@ var (
 
 func runMinionSync(conn db.Conn, store Store) {
 	loopLog := util.NewEventTimer("Etcd")
+	conn = conn.Restrict(db.MinionTable)
 	minion := getMinion(conn)
 	go syncSubnet(conn, store, minion)
-	for range conn.TriggerTick(minionTimeout/2, db.MinionTable).C {
+	for range conn.TriggerTick(minionTimeout / 2).C {
 		loopLog.LogStart()
 		writeMinion(conn, store)
 		readMinion(conn, store)

--- a/minion/etcd/network.go
+++ b/minion/etcd/network.go
@@ -70,9 +70,8 @@ func wakeChan(conn db.Conn, store Store) chan struct{} {
 	return c
 }
 
-func runNetwork(conn db.Conn, store Store) {
-	conn = conn.Restrict(db.MinionTable, db.ContainerTable, db.LabelTable,
-		db.EtcdTable)
+func runNetwork(store Store) {
+	conn := db.Open(db.MinionTable, db.ContainerTable, db.LabelTable, db.EtcdTable)
 	for range wakeChan(conn, store) {
 		// If the etcd read failed, we only want to update the db if it
 		// failed because a key was missing (has not been created yet).

--- a/minion/etcd/network.go
+++ b/minion/etcd/network.go
@@ -51,9 +51,7 @@ type storeContainerSlice []storeContainer
 // channel. Multiple redundant pings will be coalesced into a single message.
 func wakeChan(conn db.Conn, store Store) chan struct{} {
 	minionWatch := store.Watch(minionDir, 1*time.Second)
-	trigg := conn.TriggerTick(30, db.MinionTable, db.ContainerTable, db.LabelTable,
-		db.EtcdTable).C
-
+	trigg := conn.TriggerTick(30).C
 	c := make(chan struct{}, 1)
 	go func() {
 		for {
@@ -73,6 +71,8 @@ func wakeChan(conn db.Conn, store Store) chan struct{} {
 }
 
 func runNetwork(conn db.Conn, store Store) {
+	conn = conn.Restrict(db.MinionTable, db.ContainerTable, db.LabelTable,
+		db.EtcdTable)
 	for range wakeChan(conn, store) {
 		// If the etcd read failed, we only want to update the db if it
 		// failed because a key was missing (has not been created yet).

--- a/minion/etcd/run.go
+++ b/minion/etcd/run.go
@@ -1,17 +1,13 @@
 package etcd
 
-import (
-	"github.com/NetSys/quilt/db"
-)
-
-// Run synchronizes state in `conn` with the Etcd cluster.
-func Run(conn db.Conn) {
+// Run synchronizes state in the Database with the Etcd cluster.
+func Run() {
 	store := NewStore()
 	makeEtcdDir(minionDir, store, 0)
 	makeEtcdDir(subnetStore, store, 0)
 	makeEtcdDir(nodeStore, store, 0)
 
-	go runElection(conn, store)
-	go runNetwork(conn, store)
-	runMinionSync(conn, store)
+	go runElection(store)
+	go runNetwork(store)
+	runMinionSync(store)
 }

--- a/minion/keys.go
+++ b/minion/keys.go
@@ -14,7 +14,7 @@ const authorizedKeysFile = "/home/quilt/.ssh/authorized_keys"
 
 func syncAuthorizedKeys(conn db.Conn) {
 	waitForMinion(conn)
-	for range conn.TriggerTick(30, db.MinionTable).C {
+	for range conn.Restrict(db.MinionTable).TriggerTick(30).C {
 		if err := runOnce(conn); err != nil {
 			log.WithError(err).Error("Failed to sync keys")
 		}

--- a/minion/keys.go
+++ b/minion/keys.go
@@ -12,9 +12,11 @@ import (
 
 const authorizedKeysFile = "/home/quilt/.ssh/authorized_keys"
 
-func syncAuthorizedKeys(conn db.Conn) {
+func syncAuthorizedKeys() {
+	conn := db.Open(db.MinionTable)
+
 	waitForMinion(conn)
-	for range conn.Restrict(db.MinionTable).TriggerTick(30).C {
+	for range conn.TriggerTick(30).C {
 		if err := runOnce(conn); err != nil {
 			log.WithError(err).Error("Failed to sync keys")
 		}

--- a/minion/network/network.go
+++ b/minion/network/network.go
@@ -34,9 +34,7 @@ type dbslice []dbport
 // Run blocks implementing the network services.
 func Run(conn db.Conn, dk docker.Client) {
 	loopLog := util.NewEventTimer("Network")
-	for range conn.TriggerTick(30, db.MinionTable, db.ContainerTable,
-		db.ConnectionTable, db.LabelTable, db.EtcdTable).C {
-
+	for range conn.TriggerTick(30).C {
 		loopLog.LogStart()
 		runWorker(conn, dk)
 		runMaster(conn)

--- a/minion/network/network_test.go
+++ b/minion/network/network_test.go
@@ -29,7 +29,9 @@ func (lps lportslice) Swap(i, j int) {
 func TestRunMaster(t *testing.T) {
 	client := ovsdb.NewFakeOvsdbClient()
 	client.CreateLogicalSwitch(lSwitch)
-	conn := db.New()
+
+	db.Reset()
+	conn := db.Open()
 	ovsdb.Open = func() (ovsdb.Client, error) {
 		return client, nil
 	}
@@ -84,7 +86,7 @@ func TestRunMaster(t *testing.T) {
 		client.CreateLogicalPort(lSwitch, ip, mac, ip)
 	}
 
-	runMaster(conn)
+	runMaster()
 
 	lports, err := client.ListLogicalPorts(lSwitch)
 	if err != nil {

--- a/minion/network/worker.go
+++ b/minion/network/worker.go
@@ -92,7 +92,10 @@ type OFRuleSlice []OFRule
 //        * Forward arp packets to both br-int and the default gateway.
 //        * Forward packets from LOCAL to the container with the packet's dst MAC.
 
-func runWorker(conn db.Conn, dk docker.Client) {
+func runWorker(dk docker.Client) {
+	conn := db.Open(db.ContainerTable, db.LabelTable, db.ConnectionTable,
+		db.MinionTable)
+
 	minion, err := conn.MinionSelf()
 	if err != nil || !minion.SupervisorInit || minion.Role != db.Worker {
 		return

--- a/minion/run.go
+++ b/minion/run.go
@@ -42,7 +42,7 @@ func Run() {
 	go apiServer.Run(conn, fmt.Sprintf("tcp://0.0.0.0:%d", api.DefaultRemotePort))
 
 	loopLog := util.NewEventTimer("Minion-Update")
-	for range conn.Trigger(db.MinionTable).C {
+	for range conn.Restrict(db.MinionTable).Trigger().C {
 		loopLog.LogStart()
 		conn.Transact(func(view db.Database) error {
 			minion, err := view.MinionSelf()

--- a/minion/scheduler/master.go
+++ b/minion/scheduler/master.go
@@ -19,7 +19,9 @@ type context struct {
 	changed     []*db.Container
 }
 
-func runMaster(conn db.Conn) {
+func runMaster() {
+	conn := db.Open(db.EtcdTable, db.PlacementTable, db.ContainerTable,
+		db.MinionTable)
 	conn.Transact(func(view db.Database) error {
 		if view.EtcdLeader() {
 			placeContainers(view)

--- a/minion/scheduler/scheduler.go
+++ b/minion/scheduler/scheduler.go
@@ -18,6 +18,9 @@ import (
 
 // Run blocks implementing the scheduler module.
 func Run(conn db.Conn, dk docker.Client) {
+	conn = conn.Restrict(db.MinionTable, db.ContainerTable, db.PlacementTable,
+		db.EtcdTable)
+
 	bootWait(conn)
 
 	subnet := getMinionSubnet(conn)
@@ -27,9 +30,7 @@ func Run(conn db.Conn, dk docker.Client) {
 	}
 
 	loopLog := util.NewEventTimer("Scheduler")
-	trig := conn.TriggerTick(60, db.MinionTable, db.ContainerTable,
-		db.PlacementTable, db.EtcdTable).C
-	for range trig {
+	for range conn.TriggerTick(60).C {
 		loopLog.LogStart()
 		minion, err := conn.MinionSelf()
 		if err != nil {

--- a/minion/scheduler/worker.go
+++ b/minion/scheduler/worker.go
@@ -17,12 +17,13 @@ const labelValue = "scheduler"
 const labelPair = labelKey + "=" + labelValue
 const concurrencyLimit = 32
 
-func runWorker(conn db.Conn, dk docker.Client, myIP string, subnet net.IPNet) {
+func runWorker(dk docker.Client, myIP string, subnet net.IPNet) {
 	if myIP == "" {
 		return
 	}
 
 	filter := map[string][]string{"label": {labelPair}}
+	conn := db.Open(db.MinionTable, db.ContainerTable)
 
 	var toBoot, toKill []interface{}
 	for i := 0; i < 2; i++ {

--- a/minion/scheduler/worker_test.go
+++ b/minion/scheduler/worker_test.go
@@ -15,10 +15,10 @@ var (
 )
 
 func TestRunWorker(t *testing.T) {
-	t.Parallel()
+	db.Reset()
 
 	md, dk := docker.NewMock()
-	conn := db.New()
+	conn := db.Open()
 	conn.Transact(func(view db.Database) error {
 		container := view.InsertContainer()
 		container.Image = "Image"
@@ -33,20 +33,20 @@ func TestRunWorker(t *testing.T) {
 	})
 
 	// Wrong Minion IP, should do nothing.
-	runWorker(conn, dk, "1.2.3.5", *subnet)
+	runWorker(dk, "1.2.3.5", *subnet)
 	dkcs, err := dk.List(nil)
 	assert.NoError(t, err)
 	assert.Len(t, dkcs, 0)
 
 	// Run with a list error, should do nothing.
 	md.ListError = true
-	runWorker(conn, dk, "1.2.3.4", *subnet)
+	runWorker(dk, "1.2.3.4", *subnet)
 	md.ListError = false
 	dkcs, err = dk.List(nil)
 	assert.NoError(t, err)
 	assert.Len(t, dkcs, 0)
 
-	runWorker(conn, dk, "1.2.3.4", *subnet)
+	runWorker(dk, "1.2.3.4", *subnet)
 	dkcs, err = dk.List(nil)
 	assert.NoError(t, err)
 	assert.Len(t, dkcs, 1)

--- a/minion/server.go
+++ b/minion/server.go
@@ -19,9 +19,9 @@ type server struct {
 	db.Conn
 }
 
-func minionServerRun(conn db.Conn) {
+func minionServerRun() {
 	var sock net.Listener
-	server := server{conn}
+	server := server{db.Open()}
 	for {
 		var err error
 		sock, err = net.Listen("tcp", ":9999")

--- a/minion/supervisor/supervisor.go
+++ b/minion/supervisor/supervisor.go
@@ -63,8 +63,8 @@ type supervisor struct {
 }
 
 // Run blocks implementing the supervisor module.
-func Run(conn db.Conn, dk docker.Client) {
-	sv := supervisor{conn: conn, dk: dk}
+func Run(dk docker.Client) {
+	sv := supervisor{conn: db.Open(db.MinionTable, db.EtcdTable), dk: dk}
 	sv.runSystem()
 }
 
@@ -88,13 +88,13 @@ func (sv *supervisor) runSystem() {
 }
 
 func (sv *supervisor) runSystemOnce() {
-	minion, err := sv.conn.Restrict(db.MinionTable).MinionSelf()
+	minion, err := sv.conn.MinionSelf()
 	if err != nil {
 		return
 	}
 
 	var etcdRow db.Etcd
-	etcdRows := sv.conn.Restrict(db.EtcdTable).SelectFromEtcd(nil)
+	etcdRows := sv.conn.SelectFromEtcd(nil)
 	if len(etcdRows) == 1 {
 		etcdRow = etcdRows[0]
 	}

--- a/minion/supervisor/supervisor.go
+++ b/minion/supervisor/supervisor.go
@@ -80,7 +80,7 @@ func (sv *supervisor) runSystem() {
 	}
 
 	loopLog := util.NewEventTimer("Supervisor")
-	for range sv.conn.Trigger(db.MinionTable, db.EtcdTable).C {
+	for range sv.conn.Trigger().C {
 		loopLog.LogStart()
 		sv.runSystemOnce()
 		loopLog.LogEnd()
@@ -88,13 +88,14 @@ func (sv *supervisor) runSystem() {
 }
 
 func (sv *supervisor) runSystemOnce() {
-	minion, err := sv.conn.MinionSelf()
+	minion, err := sv.conn.Restrict(db.MinionTable).MinionSelf()
 	if err != nil {
 		return
 	}
 
 	var etcdRow db.Etcd
-	if etcdRows := sv.conn.SelectFromEtcd(nil); len(etcdRows) == 1 {
+	etcdRows := sv.conn.Restrict(db.EtcdTable).SelectFromEtcd(nil)
+	if len(etcdRows) == 1 {
 		etcdRow = etcdRows[0]
 	}
 

--- a/minion/supervisor/supervisor_test.go
+++ b/minion/supervisor/supervisor_test.go
@@ -371,7 +371,7 @@ func initTest() *testCtx {
 	conn := db.New()
 	md, dk := docker.NewMock()
 	ctx := testCtx{supervisor{}, fakeDocker{dk, md}, nil, conn,
-		conn.Trigger(db.MinionTable, db.EtcdTable)}
+		conn.Restrict(db.MinionTable, db.EtcdTable).Trigger()}
 	ctx.sv.conn = ctx.conn
 	ctx.sv.dk = ctx.fd.Client
 

--- a/minion/supervisor/supervisor_test.go
+++ b/minion/supervisor/supervisor_test.go
@@ -368,10 +368,11 @@ type testCtx struct {
 }
 
 func initTest() *testCtx {
-	conn := db.New()
+	db.Reset()
+	conn := db.Open()
 	md, dk := docker.NewMock()
 	ctx := testCtx{supervisor{}, fakeDocker{dk, md}, nil, conn,
-		conn.Restrict(db.MinionTable, db.EtcdTable).Trigger()}
+		db.TriggerOn(db.MinionTable, db.EtcdTable)}
 	ctx.sv.conn = ctx.conn
 	ctx.sv.dk = ctx.fd.Client
 

--- a/quiltctl/command/daemon.go
+++ b/quiltctl/command/daemon.go
@@ -3,7 +3,6 @@ package command
 import (
 	"github.com/NetSys/quilt/api/server"
 	"github.com/NetSys/quilt/cluster"
-	"github.com/NetSys/quilt/db"
 	"github.com/NetSys/quilt/engine"
 )
 
@@ -26,9 +25,8 @@ func (dCmd *Daemon) Parse(args []string) error {
 
 // Run starts the daemon.
 func (dCmd *Daemon) Run() int {
-	conn := db.New()
-	go engine.Run(conn)
-	go server.Run(conn, dCmd.host)
-	cluster.Run(conn)
+	go engine.Run()
+	go server.Run(dCmd.host)
+	cluster.Run()
 	return 0
 }


### PR DESCRIPTION
This patch reduces the lock granularity on the db to the table level, allowing transactions that operate on independent table sets to run concurrently. 