### PR TITLE
quiltctl: 'quilt stop' halts current cluster

### DIFF
--- a/quiltctl/command/stop.go
+++ b/quiltctl/command/stop.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 
@@ -9,10 +10,6 @@ import (
 	"github.com/NetSys/quilt/api/client"
 	"github.com/NetSys/quilt/api/client/getter"
 )
-
-// The default namespace to use when stopping. This should match the default
-// namespace used in `stitch/bindings.js`.
-const defaultNamespace = "default-namespace"
 
 // Stop contains the options for stopping namespaces.
 type Stop struct {
@@ -34,7 +31,7 @@ func NewStopCommand() *Stop {
 func (sCmd *Stop) InstallFlags(flags *flag.FlagSet) {
 	sCmd.common.InstallFlags(flags)
 
-	flags.StringVar(&sCmd.namespace, "namespace", defaultNamespace,
+	flags.StringVar(&sCmd.namespace, "namespace", "",
 		"the namespace to stop")
 
 	flags.Usage = func() {
@@ -66,6 +63,15 @@ func (sCmd *Stop) Run() int {
 	}
 	defer c.Close()
 
+	if sCmd.namespace == "" {
+		sCmd.namespace, err = clusterName(c)
+		if err != nil {
+			log.WithError(err).
+				Error("Failed to get namespace of current cluster")
+			return 1
+		}
+	}
+
 	specStr := fmt.Sprintf(`{"namespace": %q}`, sCmd.namespace)
 	if err = c.Deploy(specStr); err != nil {
 		log.WithError(err).Error("Unable to stop namespace.")
@@ -74,4 +80,20 @@ func (sCmd *Stop) Run() int {
 
 	log.WithField("namespace", sCmd.namespace).Debug("Stopping namespace")
 	return 0
+}
+
+// Returns the name of the current cluster
+func clusterName(c client.Client) (string, error) {
+	clusters, err := c.QueryClusters()
+	if err != nil {
+		return "", err
+	}
+	switch len(clusters) {
+	case 0:
+		return "", errors.New("no cluster set")
+	case 1:
+		return clusters[0].Namespace, nil
+	default:
+		panic("more than 1 current cluster")
+	}
 }


### PR DESCRIPTION
'quilt stop' with no arguments will now halt the current cluster.
Consequently, the default namespace for 'quilt stop' is no longer
'default-namespace', so halting 'default-namespace' must now be done
with 'quilt stop default-namespace'.