### PR TITLE
util: Refactor quilt-tester to use util.WaitFor

### DIFF
--- a/quilt-tester/tester_test.go
+++ b/quilt-tester/tester_test.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -34,33 +33,6 @@ func TestCmdExec(t *testing.T) {
 	}
 	if stderr != expStderr {
 		t.Errorf("Stderr didn't match: expected %s, got %s", expStderr, stderr)
-	}
-}
-
-func TestWaitFor(t *testing.T) {
-	sleep = func(t time.Duration) {}
-
-	calls := 0
-	callThreeTimes := func() bool {
-		calls++
-		if calls == 3 {
-			return true
-		}
-		return false
-	}
-	err := waitFor(callThreeTimes, 5)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err.Error())
-	}
-	if calls != 3 {
-		t.Errorf("Incorrect number of calls to predicate: %d", calls)
-	}
-
-	err = waitFor(func() bool {
-		return false
-	}, 300*time.Millisecond)
-	if err.Error() != "timed out" {
-		t.Errorf("Expected waitFor to timeout")
 	}
 }
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 )
 
 func TestToTar(t *testing.T) {
@@ -85,4 +86,31 @@ func ed(a, b []string, exp int) string {
 		return fmt.Sprintf("Distance(%s, %s) = %v, expected %v", a, b, ed, exp)
 	}
 	return ""
+}
+
+func TestWaitFor(t *testing.T) {
+	Sleep = func(t time.Duration) {}
+
+	calls := 0
+	callThreeTimes := func() bool {
+		calls++
+		if calls == 3 {
+			return true
+		}
+		return false
+	}
+	err := WaitFor(callThreeTimes, 1*time.Second, 5*time.Second)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+	if calls != 3 {
+		t.Errorf("Incorrect number of calls to predicate: %d", calls)
+	}
+
+	err = WaitFor(func() bool {
+		return false
+	}, 1*time.Second, 300*time.Millisecond)
+	if err.Error() != "timed out" {
+		t.Errorf("Expected waitFor to timeout")
+	}
 }


### PR DESCRIPTION
This generalizes the `waitFor()` function from quilt-tester/exec
to accept an arbitrary timeout and migrates it to the `util` package
so that other packages can make use of it.