### PR TITLE
etcd: Fix a compiler warning

### DIFF
--- a/minion/etcd/network_test.go
+++ b/minion/etcd/network_test.go
@@ -55,7 +55,7 @@ func TestUpdateEtcdContainers(t *testing.T) {
 
 	*store.writes = 0
 	etcdDBCs, _ := readEtcd(store)
-	etcdDBCs, _ = updateEtcdContainer(store, etcdDBCs, containers)
+	updateEtcdContainer(store, etcdDBCs, containers)
 
 	resultContainers, err := store.Get(containerStore)
 	assert.Nil(t, err)


### PR DESCRIPTION
We were getting the following warning in minion/etcd/network_test.go:
`ineffectual assignment to etcdDBCs`.