### PR TITLE
Container ID UX Improvements

### DIFF
--- a/api/util/util.go
+++ b/api/util/util.go
@@ -15,10 +15,25 @@ func GetContainer(c client.Client, stitchID string) (db.Container, error) {
 		return db.Container{}, err
 	}
 
+	var choice *db.Container
 	for _, c := range containers {
-		if c.StitchID == stitchID {
-			return c, nil
+		if len(stitchID) > len(c.StitchID) ||
+			c.StitchID[0:len(stitchID)] != stitchID {
+			continue
 		}
+
+		if choice != nil {
+			err := fmt.Errorf("ambiguous stitchIDs %s and %s",
+				choice.StitchID, c.StitchID)
+			return db.Container{}, err
+		}
+
+		copy := c
+		choice = &copy
+	}
+
+	if choice != nil {
+		return *choice, nil
 	}
 
 	return db.Container{}, fmt.Errorf("no container with stitchID %q", stitchID)

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -12,30 +12,33 @@ import (
 func TestGetContainer(t *testing.T) {
 	t.Parallel()
 
-	passedContainer := db.Container{
-		StitchID: "1",
-	}
-	c := &mocks.Client{
-		ContainerReturn: []db.Container{
-			passedContainer,
-			{StitchID: "2"},
-			{StitchID: "3"},
-		},
-	}
-	res, err := GetContainer(c, passedContainer.StitchID)
+	a := db.Container{StitchID: "4567"}
+	b := db.Container{StitchID: "432"}
+	c := &mocks.Client{ContainerReturn: []db.Container{a, b}}
+
+	res, err := GetContainer(c, "4567")
 	assert.Nil(t, err)
-	assert.Equal(t, passedContainer, res)
-}
+	assert.Equal(t, a, res)
 
-func TestGetContainerErr(t *testing.T) {
-	t.Parallel()
+	res, err = GetContainer(c, "456")
+	assert.Nil(t, err)
+	assert.Equal(t, a, res)
 
-	c := &mocks.Client{
-		ContainerReturn: []db.Container{
-			{StitchID: "2"},
-			{StitchID: "3"},
-		},
-	}
-	_, err := GetContainer(c, "1")
+	res, err = GetContainer(c, "45")
+	assert.Nil(t, err)
+	assert.Equal(t, a, res)
+
+	res, err = GetContainer(c, "432")
+	assert.Nil(t, err)
+	assert.Equal(t, b, res)
+
+	res, err = GetContainer(c, "43")
+	assert.Nil(t, err)
+	assert.Equal(t, b, res)
+
+	_, err = GetContainer(c, "4")
+	assert.EqualError(t, err, `ambiguous stitchIDs 4567 and 432`)
+
+	_, err = GetContainer(c, "1")
 	assert.EqualError(t, err, `no container with stitchID "1"`)
 }

--- a/quiltctl/command/container.go
+++ b/quiltctl/command/container.go
@@ -16,6 +16,7 @@ import (
 	"github.com/NetSys/quilt/api/client"
 	"github.com/NetSys/quilt/api/client/getter"
 	"github.com/NetSys/quilt/db"
+	"github.com/NetSys/quilt/util"
 )
 
 // Container contains the options for querying containers.
@@ -162,8 +163,8 @@ func writeContainers(fd io.Writer, containers []db.Container, machines []db.Mach
 				publicPorts)
 
 			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-				dbc.StitchID, machine, container, labels, status,
-				created, publicIP)
+				util.ShortUUID(dbc.StitchID), machine, container, labels,
+				status, created, publicIP)
 		}
 	}
 }


### PR DESCRIPTION
The new longer stitch IDs required me to copy and paste them from my terminal which I found intolerable.  This series change is it so you need only type the prefix of an ID (much like is possible with git and docker).  It also prints shortened IDs instead of the full length version to make `quilt ps` more readable.