### PR TITLE
minion: Join containers based exclusively on the StitchID

### DIFF
--- a/minion/engine_test.go
+++ b/minion/engine_test.go
@@ -1,13 +1,11 @@
 package minion
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/NetSys/quilt/db"
 	"github.com/NetSys/quilt/stitch"
-	"github.com/NetSys/quilt/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -99,9 +97,7 @@ func testContainerTxn(t *testing.T, conn db.Conn, spec string) {
 	for _, e := range queryContainers(compiled) {
 		found := false
 		for i, c := range containers {
-			if e.Image == c.Image &&
-				reflect.DeepEqual(e.Command, c.Command) &&
-				util.EditDistance(c.Labels, e.Labels) == 0 {
+			if e.StitchID == c.StitchID {
 				containers = append(containers[:i], containers[i+1:]...)
 				found = true
 				break

--- a/util/util.go
+++ b/util/util.go
@@ -72,27 +72,6 @@ func ShortUUID(uuid string) string {
 	return uuid[:12]
 }
 
-// EditDistance returns the number of strings that are in exclusively `a` or `b`.
-func EditDistance(a, b []string) int {
-	amap := make(map[string]struct{})
-
-	for _, label := range a {
-		amap[label] = struct{}{}
-	}
-
-	ed := 0
-	for _, label := range b {
-		if _, ok := amap[label]; ok {
-			delete(amap, label)
-		} else {
-			ed++
-		}
-	}
-
-	ed += len(amap)
-	return ed
-}
-
 // AppFs is an aero filesystem.  It is stored in a variable so that we can replace it
 // with in-memory filesystems for unit tests.
 var AppFs = afero.NewOsFs()

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -39,55 +39,6 @@ func TestToTar(t *testing.T) {
 	}
 }
 
-func TestEditDistance(t *testing.T) {
-	if err := ed(nil, nil, 0); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"a"}, nil, 1); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed(nil, []string{"a"}, 1); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"a"}, []string{"a"}, 0); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"b"}, []string{"a"}, 2); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"b", "a"}, []string{"a"}, 1); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"b", "a"}, []string{}, 2); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"a", "b", "c"}, []string{"a", "b", "c"}, 0); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"b", "c"}, []string{"a", "b", "c"}, 1); err != "" {
-		t.Error(err)
-	}
-
-	if err := ed([]string{"b", "c"}, []string{"a", "c"}, 2); err != "" {
-		t.Error(err)
-	}
-}
-
-func ed(a, b []string, exp int) string {
-	if ed := EditDistance(a, b); ed != exp {
-		return fmt.Sprintf("Distance(%s, %s) = %v, expected %v", a, b, ed, exp)
-	}
-	return ""
-}
-
 func TestWaitFor(t *testing.T) {
 	Sleep = func(t time.Duration) {}
 


### PR DESCRIPTION
Now that the StitchID is more carefully crafted by Quilt.js, it seems
logical (and makes the system easier to reason about) if a given
container always maintains the same StitchID even as the spec changes.

This fixes a bug where booting a second copy of a particular system
on the same infrastructure could cause new nodes to connect to the
old system.